### PR TITLE
Add WarpCalib smoke and 1D spectrum regression tests

### DIFF
--- a/Warp_calib.py
+++ b/Warp_calib.py
@@ -6,7 +6,6 @@ from pyraf import iraf
 from iraf import onedspec
 import os
 import shutil
-import subprocess
 import glob
 import numpy as np
 import argparse
@@ -21,10 +20,8 @@ from warp.cutransform import cutransform
 from warp.badpixmask import badpixmask_flaton, badpixmask_flatoff, pyfixpix, deadpixmap_inter
 from warp.apscatter import pyapscatter
 from warp.auto_ecidentify import auto_ecidentify
-from warp.Resolution import resolution_measure
-from warp.spectrum_map import spectrum_mapping
 from warp.fits_utils import header_key_read
-from warp.Spec1Dtools import pyapall, truncate, dispcor_single
+from warp.Spec1Dtools import pyapall, truncate
 
 # from ECtoID_v1_3 import ECtoID
 

--- a/docs/1d_spectrum_regression_tests.md
+++ b/docs/1d_spectrum_regression_tests.md
@@ -1,0 +1,48 @@
+# 1D spectrum regression tests
+
+The most important scientific product of `Warp_sci.py` is the extracted 1D
+spectrum.  The lightweight regression helper added here records numerical
+summaries of those FITS files instead of committing the generated FITS products
+themselves.
+
+The summary currently covers the final per-order and combined files below each
+`*_sum` directory:
+
+- `AIR_norm/fsr*/*.fits`
+- `VAC_norm/fsr*/*.fits`
+- `AIR_flux/fsr*/*.fits`
+- `VAC_flux/fsr*/*.fits`
+
+For each 1D FITS file, the summary records the wavelength calibration header,
+derived wavelength range and step, flux statistics, percentiles, and a few
+sample/window values across the spectrum.  This keeps the reference file small
+while still catching changes in wavelength coverage, sampling, flux scale, and
+local spectral shape.
+
+## Generate a summary
+
+```sh
+python tools/summarize_1d_spectra.py TEST/4_Ari_WIDE_test \
+  --output tests/reference/wide_4_ari_1d_summary.json
+```
+
+For a freshly generated temporary output from `testWarpSci.sh`, keep the output
+directory first:
+
+```sh
+KEEP_WARP_TEST_OUTPUT=1 ./testWarpSci.sh
+python tools/summarize_1d_spectra.py /path/to/4_Ari_WIDE_test \
+  --output /tmp/wide_4_ari_1d_summary.json
+```
+
+## Compare output against the committed reference
+
+The regression comparison is opt-in because it needs a generated WARP output
+tree:
+
+```sh
+WARP_1D_OUTPUT_ROOT=TEST/4_Ari_WIDE_test python -m pytest -q -m regression
+```
+
+Normal `pytest` runs still execute without generated WARP outputs; the
+reference comparison is skipped unless `WARP_1D_OUTPUT_ROOT` is set.

--- a/docs/test_shell_scripts.md
+++ b/docs/test_shell_scripts.md
@@ -1,0 +1,63 @@
+# Test Shell Scripts
+
+This document summarizes the repository-level shell smoke tests.
+
+## Common Behavior
+
+The shell scripts can be run from the repository root:
+
+```sh
+./testWarpSci.sh
+./testWarpSciFull.sh
+./testWarpCalib.sh
+```
+
+They use paths relative to the script location, so they do not depend on the
+caller manually typing `./TEST/...` paths.
+
+The scripts set `PYRAF_NO_DISPLAY=1` by default for non-interactive PyRAF runs.
+On local macOS runs, they also map an inherited `IRAFARCH=macintel` to
+`IRAFARCH=macos64`.  Override this with `WARP_IRAFARCH` if needed.
+
+By default, generated outputs are written under a temporary directory and
+removed at the end of the run.  To keep the outputs for inspection:
+
+```sh
+KEEP_WARP_TEST_OUTPUT=1 ./testWarpSci.sh
+```
+
+To select a Python interpreter:
+
+```sh
+PYTHON=/path/to/python ./testWarpSci.sh
+```
+
+For PyRAF/IRAF-backed runs, also set `iraf` when it is not already available in
+the shell:
+
+```sh
+PYTHON=/path/to/python iraf=/path/to/iraf/ ./testWarpCalib.sh
+```
+
+## Scripts
+
+- `testWarpSci.sh`
+  - WIDE science fast smoke test.
+  - Uses `TEST/WIDE/4_Ari_list.txt`.
+  - Runs with `-f`.
+- `testWarpSciFull.sh`
+  - Longer science smoke suite.
+  - Runs WIDE, WIDE with sky-subtraction parameters, HIRES-J, and HIRES-Y.
+  - Intended for manual validation, not quick review.
+- `testWarpCalib.sh`
+  - WIDE calibration smoke test.
+  - Uses `TEST/WIDE-calib/input.list`.
+  - Copies the fixture into a temporary working directory because
+    `Warp_calib.py` creates many intermediate products in the current
+    directory.
+
+## Current Limits
+
+These scripts are smoke tests.  They check that representative pipeline runs
+complete and that selected output files exist.  They do not yet compare
+numerical output values against reference summaries.

--- a/docs/warp_calib_smoke_test.md
+++ b/docs/warp_calib_smoke_test.md
@@ -1,0 +1,87 @@
+# Warp_calib Smoke Test
+
+This document records the first lightweight execution coverage for
+`Warp_calib.py`.
+
+## Scope
+
+The smoke test runs the WIDE calibration fixture:
+
+- input directory: `TEST/WIDE-calib/`
+- input list: `input.list`
+- command target: `Warp_calib.py`
+
+The test checks that calibration output is created, but it does not yet compare
+numerical output values against a reference baseline.
+
+## Script
+
+Use:
+
+```sh
+./testWarpCalib.sh
+```
+
+The script:
+
+- copies `TEST/WIDE-calib/` into a temporary working directory
+- copies `$HOME/login.cl` into that working directory when available
+- creates a local `uparm/` directory
+- sets `PYRAF_NO_DISPLAY=1` by default
+- maps an inherited `IRAFARCH=macintel` to `IRAFARCH=macos64`
+- runs `Warp_calib.py input.list`
+- verifies that the expected calibration products exist
+
+To choose a Python interpreter explicitly:
+
+```sh
+PYTHON=/path/to/python iraf=/path/to/iraf/ ./testWarpCalib.sh
+```
+
+To keep the temporary output directory for inspection:
+
+```sh
+KEEP_WARP_TEST_OUTPUT=1 PYTHON=/path/to/python iraf=/path/to/iraf/ ./testWarpCalib.sh
+```
+
+## Verified Locally
+
+The WIDE calibration smoke test completed successfully in:
+
+- Python 3.7.16 Astroconda/PyRAF environment
+- Python 3.13.5 test environment with PyRAF 2.2.4
+
+Both runs used:
+
+```sh
+iraf=/Users/hamano/iraf/iraf-2.17.1/
+IRAFARCH=macos64
+```
+
+## Environment Notes
+
+`Warp_calib.py` is more sensitive to IRAF initialization than the current
+`Warp_sci.py` smoke test.
+
+Without a local `login.cl` and `uparm/`, the Astroconda/PyRAF run reached
+`apscatter` and failed because IRAF variable `uparm` was undefined.
+
+With a stale inherited `IRAFARCH=macintel`, PyRAF looked for:
+
+```text
+bin.macintel/x_system.e
+```
+
+The working Community IRAF installation provides the executable under:
+
+```text
+bin.macos64/x_system.e
+```
+
+The smoke script handles this local macOS case by defaulting to `macos64`.
+
+## Remaining Work
+
+- Add numerical regression summaries for the generated calibration products.
+- Add HIRES-Y and HIRES-J calibration smoke coverage.
+- Refactor `Warp_calib.py` only after the calibration baseline is stronger.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    regression: opt-in tests that compare generated WARP products with reference outputs

--- a/testWarpCalib.sh
+++ b/testWarpCalib.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+PYTHON=${PYTHON:-python3}
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TMPBASE=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "$TMPBASE/warp-calib-wide.XXXXXX")
+
+cleanup() {
+    if [ "${KEEP_WARP_TEST_OUTPUT:-0}" = "1" ]; then
+        echo "Keeping test output in $WORKDIR"
+    else
+        rm -rf "$WORKDIR"
+    fi
+}
+trap cleanup EXIT
+
+cp -R "$ROOT/TEST/WIDE-calib/." "$WORKDIR/"
+
+if [ -f "$HOME/login.cl" ]; then
+    cp "$HOME/login.cl" "$WORKDIR/login.cl"
+fi
+mkdir -p "$WORKDIR/uparm"
+
+export PYRAF_NO_DISPLAY=${PYRAF_NO_DISPLAY:-1}
+if [ -n "${WARP_IRAFARCH:-}" ]; then
+    IRAFARCH=$WARP_IRAFARCH
+elif [ -z "${IRAFARCH:-}" ] || [ "${IRAFARCH:-}" = "macintel" ]; then
+    IRAFARCH=macos64
+fi
+export IRAFARCH
+
+if [ -z "${iraf:-}" ]; then
+    echo "Warning: iraf is not set. PyRAF/IRAF may fail unless it can find a default IRAF installation."
+fi
+
+(
+    cd "$WORKDIR"
+    "$PYTHON" "$ROOT/Warp_calib.py" input.list
+)
+
+test -f "$WORKDIR/calibration_LCO22b_setting3_WIDE100/input_files.txt"
+test -f "$WORKDIR/calibration_LCO22b_setting3_WIDE100/flat_WIDE100_20220915_mscmn.fits"
+test -f "$WORKDIR/calibration_LCO22b_setting3_WIDE100/mask_flat_WIDE100_20220915.fits"
+test -f "$WORKDIR/calibration_LCO22b_setting3_WIDE100/comp_WIDE100_20220915_fm_ecall.fits"
+
+echo "Warp_calib WIDE smoke test finished successfully."

--- a/testWarpSci.sh
+++ b/testWarpSci.sh
@@ -1,6 +1,37 @@
 #!/bin/sh
-
 set -eu
 
 PYTHON=${PYTHON:-python3}
-"$PYTHON" Warp_sci.py ./TEST/WIDE/4_Ari_list.txt -r ./TEST/WIDE/ -c ./TEST/WIDE/WINERED_calibration_LCO22b_WIDE100_20220914_v2/ -v ./TEST/WIDE/ -d ./TEST/4_Ari_WIDE_test -f
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TMPBASE=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "$TMPBASE/warp-sci-wide.XXXXXX")
+
+export PYRAF_NO_DISPLAY=${PYRAF_NO_DISPLAY:-1}
+if [ -n "${WARP_IRAFARCH:-}" ]; then
+    IRAFARCH=$WARP_IRAFARCH
+elif [ -z "${IRAFARCH:-}" ] || [ "${IRAFARCH:-}" = "macintel" ]; then
+    IRAFARCH=macos64
+fi
+export IRAFARCH
+
+cleanup() {
+    if [ "${KEEP_WARP_TEST_OUTPUT:-0}" = "1" ]; then
+        echo "Keeping test output in $WORKDIR"
+    else
+        rm -rf "$WORKDIR"
+    fi
+}
+trap cleanup EXIT
+
+"$PYTHON" "$ROOT/Warp_sci.py" \
+    "$ROOT/TEST/WIDE/4_Ari_list.txt" \
+    -r "$ROOT/TEST/WIDE/" \
+    -c "$ROOT/TEST/WIDE/WINERED_calibration_LCO22b_WIDE100_20220914_v2/" \
+    -v "$ROOT/TEST/WIDE/" \
+    -d "$WORKDIR/4_Ari_WIDE_test" \
+    -f
+
+test -f "$WORKDIR/4_Ari_WIDE_test/calibration_data/input_files.txt"
+test -f "$WORKDIR/4_Ari_WIDE_test/reduction_log/status.txt"
+
+echo "Warp_sci WIDE fast smoke test finished successfully."

--- a/testWarpSciFull.sh
+++ b/testWarpSciFull.sh
@@ -1,10 +1,55 @@
 #!/bin/sh
-
 set -eu
 
 PYTHON=${PYTHON:-python3}
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TMPBASE=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "$TMPBASE/warp-sci-full.XXXXXX")
 
-"$PYTHON" Warp_sci.py ./TEST/WIDE/4_Ari_list.txt -r ./TEST/WIDE/ -c ./TEST/WIDE/WINERED_calibration_LCO22b_WIDE100_20220914_v2/ -v ./TEST/WIDE/ -d ./TEST/4_Ari_WIDE_test_def
-"$PYTHON" Warp_sci.py ./TEST/WIDE/4_Ari_list.txt -r ./TEST/WIDE/ -c ./TEST/WIDE/WINERED_calibration_LCO22b_WIDE100_20220914_v2/ -v ./TEST/WIDE/ -d ./TEST/4_Ari_WIDE_test_skysub -p ./TEST/WIDE/paramSample.txt
-"$PYTHON" Warp_sci.py ./TEST/HIRES-J/21_Peg_list.txt -r ./TEST/HIRES-J/ -c ./TEST/HIRES-J/WINERED_calibration_NTTrun_HIRESJ_20170728/ -v ./TEST/HIRES-J/ -d ./TEST/21_Peg_HIRESJ_test
-"$PYTHON" Warp_sci.py ./TEST/HIRES-Y/HD_163336_list.txt -r ./TEST/HIRES-Y/ -c ./TEST/HIRES-Y/WINERED_calibration_NTTrun_HIRESY_20170727/ -v ./TEST/HIRES-Y/ -d ./TEST/HD_163336_HIRESY_test
+export PYRAF_NO_DISPLAY=${PYRAF_NO_DISPLAY:-1}
+if [ -n "${WARP_IRAFARCH:-}" ]; then
+    IRAFARCH=$WARP_IRAFARCH
+elif [ -z "${IRAFARCH:-}" ] || [ "${IRAFARCH:-}" = "macintel" ]; then
+    IRAFARCH=macos64
+fi
+export IRAFARCH
+
+cleanup() {
+    if [ "${KEEP_WARP_TEST_OUTPUT:-0}" = "1" ]; then
+        echo "Keeping test output in $WORKDIR"
+    else
+        rm -rf "$WORKDIR"
+    fi
+}
+trap cleanup EXIT
+
+"$PYTHON" "$ROOT/Warp_sci.py" \
+    "$ROOT/TEST/WIDE/4_Ari_list.txt" \
+    -r "$ROOT/TEST/WIDE/" \
+    -c "$ROOT/TEST/WIDE/WINERED_calibration_LCO22b_WIDE100_20220914_v2/" \
+    -v "$ROOT/TEST/WIDE/" \
+    -d "$WORKDIR/4_Ari_WIDE_test_def"
+
+"$PYTHON" "$ROOT/Warp_sci.py" \
+    "$ROOT/TEST/WIDE/4_Ari_list.txt" \
+    -r "$ROOT/TEST/WIDE/" \
+    -c "$ROOT/TEST/WIDE/WINERED_calibration_LCO22b_WIDE100_20220914_v2/" \
+    -v "$ROOT/TEST/WIDE/" \
+    -d "$WORKDIR/4_Ari_WIDE_test_skysub" \
+    -p "$ROOT/TEST/WIDE/paramSample.txt"
+
+"$PYTHON" "$ROOT/Warp_sci.py" \
+    "$ROOT/TEST/HIRES-J/21_Peg_list.txt" \
+    -r "$ROOT/TEST/HIRES-J/" \
+    -c "$ROOT/TEST/HIRES-J/WINERED_calibration_NTTrun_HIRESJ_20170728/" \
+    -v "$ROOT/TEST/HIRES-J/" \
+    -d "$WORKDIR/21_Peg_HIRESJ_test"
+
+"$PYTHON" "$ROOT/Warp_sci.py" \
+    "$ROOT/TEST/HIRES-Y/HD_163336_list.txt" \
+    -r "$ROOT/TEST/HIRES-Y/" \
+    -c "$ROOT/TEST/HIRES-Y/WINERED_calibration_NTTrun_HIRESY_20170727/" \
+    -v "$ROOT/TEST/HIRES-Y/" \
+    -d "$WORKDIR/HD_163336_HIRESY_test"
+
+echo "Full Warp_sci smoke tests finished successfully."

--- a/tests/reference/wide_4_ari_1d_summary.json
+++ b/tests/reference/wide_4_ari_1d_summary.json
@@ -1,0 +1,10175 @@
+{
+  "file_count": 82,
+  "files": [
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1503,
+        "inf_count": 0,
+        "max": 13126.12109375,
+        "mean": 8943.278562153646,
+        "median": 10161.49609375,
+        "min": -1907.60205078125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -599.8630688476562,
+          "25": 6098.18408203125,
+          "5": 1945.5074707031251,
+          "50": 10161.49609375,
+          "75": 11946.4794921875,
+          "95": 12791.86181640625,
+          "99": 12974.4398046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 10758.06640625
+          },
+          {
+            "index": 375,
+            "value": 12483.2734375
+          },
+          {
+            "index": 751,
+            "value": 11561.4765625
+          },
+          {
+            "index": 1127,
+            "value": 7994.7900390625
+          },
+          {
+            "index": 1502,
+            "value": -1580.688720703125
+          }
+        ],
+        "size": 1503,
+        "std": 3582.1699778471643,
+        "sum": 13441747.678916931,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 12318.759765625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 375,
+            "median": 12459.615234375,
+            "start_index": 373,
+            "stop_index": 378
+          },
+          {
+            "center_index": 751,
+            "median": 11561.4765625,
+            "start_index": 749,
+            "stop_index": 754
+          },
+          {
+            "center_index": 1127,
+            "median": 7994.7900390625,
+            "start_index": 1125,
+            "stop_index": 1130
+          },
+          {
+            "center_index": 1502,
+            "median": -1125.7740478515625,
+            "start_index": 1500,
+            "stop_index": 1503
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.222444582710918,
+        "CRPIX1": 1.0,
+        "CRVAL1": 13179.9330998032,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1503
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m42_fsr1.05_AIR.fits",
+      "shape": [
+        1503
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13514.044863034998,
+        "max": 13514.044863034998,
+        "min": 13179.9330998032,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 13179.9330998032
+          },
+          {
+            "index": 375,
+            "value": 13263.349818319793
+          },
+          {
+            "index": 751,
+            "value": 13346.9889814191
+          },
+          {
+            "index": 1127,
+            "value": 13430.628144518405
+          },
+          {
+            "index": 1502,
+            "value": 13514.044863034998
+          }
+        ],
+        "start": 13179.9330998032,
+        "step": 0.222444582710918,
+        "step_median": 0.2224445827105228,
+        "step_std": 7.498470674615173e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1423,
+        "inf_count": 0,
+        "max": 11024.609375,
+        "mean": 10071.4623862164,
+        "median": 10509.5703125,
+        "min": 4368.78076171875,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 6105.855302734375,
+          "25": 10100.39599609375,
+          "5": 7427.32587890625,
+          "50": 10509.5703125,
+          "75": 10647.7890625,
+          "95": 10777.418359375,
+          "99": 10925.8698046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 10283.7197265625
+          },
+          {
+            "index": 355,
+            "value": 10394.421875
+          },
+          {
+            "index": 711,
+            "value": 10315.32421875
+          },
+          {
+            "index": 1067,
+            "value": 10602.203125
+          },
+          {
+            "index": 1422,
+            "value": 6775.037109375
+          }
+        ],
+        "size": 1423,
+        "std": 1071.2034285561363,
+        "sum": 14331690.975585938,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 10433.1796875,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 355,
+            "median": 10510.248046875,
+            "start_index": 353,
+            "stop_index": 358
+          },
+          {
+            "center_index": 711,
+            "median": 10315.32421875,
+            "start_index": 709,
+            "stop_index": 714
+          },
+          {
+            "center_index": 1067,
+            "median": 10602.203125,
+            "start_index": 1065,
+            "stop_index": 1070
+          },
+          {
+            "center_index": 1422,
+            "median": 6779.71826171875,
+            "start_index": 1420,
+            "stop_index": 1423
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.21746673193894,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12885.8059644196,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1423
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m43_fsr1.05_AIR.fits",
+      "shape": [
+        1423
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13195.043657236773,
+        "max": 13195.043657236773,
+        "min": 12885.8059644196,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12885.8059644196
+          },
+          {
+            "index": 355,
+            "value": 12963.006654257924
+          },
+          {
+            "index": 711,
+            "value": 13040.424810828186
+          },
+          {
+            "index": 1067,
+            "value": 13117.842967398448
+          },
+          {
+            "index": 1422,
+            "value": 13195.043657236773
+          }
+        ],
+        "start": 12885.8059644196,
+        "step": 0.21746673193894,
+        "step_median": 0.21746673193956667,
+        "step_std": 8.644434121311479e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1444,
+        "inf_count": 0,
+        "max": 10659.169921875,
+        "mean": 9618.207985494935,
+        "median": 10082.2958984375,
+        "min": 3448.692626953125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 5669.552060546875,
+          "25": 9310.712646484375,
+          "5": 7046.575390625,
+          "50": 10082.2958984375,
+          "75": 10286.30712890625,
+          "95": 10571.23134765625,
+          "99": 10626.231494140626
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 10060.9072265625
+          },
+          {
+            "index": 361,
+            "value": 10249.087890625
+          },
+          {
+            "index": 722,
+            "value": 10554.1796875
+          },
+          {
+            "index": 1083,
+            "value": 8340.5625
+          },
+          {
+            "index": 1443,
+            "value": 10130.0908203125
+          }
+        ],
+        "size": 1444,
+        "std": 1109.9978004259417,
+        "sum": 13888692.331054688,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 10130.0234375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 361,
+            "median": 10185.693359375,
+            "start_index": 359,
+            "stop_index": 364
+          },
+          {
+            "center_index": 722,
+            "median": 10564.279296875,
+            "start_index": 720,
+            "stop_index": 725
+          },
+          {
+            "center_index": 1083,
+            "median": 8330.0244140625,
+            "start_index": 1081,
+            "stop_index": 1086
+          },
+          {
+            "center_index": 1443,
+            "median": 10130.0908203125,
+            "start_index": 1441,
+            "stop_index": 1444
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.212704536480577,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12593.3404943131,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1444
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m44_fsr1.05_AIR.fits",
+      "shape": [
+        1444
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12900.273140454574,
+        "max": 12900.273140454574,
+        "min": 12593.3404943131,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12593.3404943131
+          },
+          {
+            "index": 361,
+            "value": 12670.126831982589
+          },
+          {
+            "index": 722,
+            "value": 12746.913169652078
+          },
+          {
+            "index": 1083,
+            "value": 12823.699507321566
+          },
+          {
+            "index": 1443,
+            "value": 12900.273140454574
+          }
+        ],
+        "start": 12593.3404943131,
+        "step": 0.212704536480577,
+        "step_median": 0.21270453648139664,
+        "step_std": 9.050177769972554e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1388,
+        "inf_count": 0,
+        "max": 11998.513671875,
+        "mean": 11487.43682034627,
+        "median": 11644.03759765625,
+        "min": 6467.1806640625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 9507.35220703125,
+          "25": 11372.27294921875,
+          "5": 10574.24267578125,
+          "50": 11644.03759765625,
+          "75": 11811.914794921875,
+          "95": 11899.131982421875,
+          "99": 11944.26443359375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 11406.28515625
+          },
+          {
+            "index": 347,
+            "value": 11863.22265625
+          },
+          {
+            "index": 694,
+            "value": 11506.1376953125
+          },
+          {
+            "index": 1041,
+            "value": 11405.71875
+          },
+          {
+            "index": 1387,
+            "value": 10340.9140625
+          }
+        ],
+        "size": 1388,
+        "std": 512.5756262326794,
+        "sum": 15944562.306640625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 11462.109375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 347,
+            "median": 11840.01171875,
+            "start_index": 345,
+            "stop_index": 350
+          },
+          {
+            "center_index": 694,
+            "median": 11506.1376953125,
+            "start_index": 692,
+            "stop_index": 697
+          },
+          {
+            "center_index": 1041,
+            "median": 11405.71875,
+            "start_index": 1039,
+            "stop_index": 1044
+          },
+          {
+            "center_index": 1387,
+            "median": 10599.81640625,
+            "start_index": 1385,
+            "stop_index": 1388
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.208052282624997,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12318.7519760701,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1388
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m45_fsr1.05_AIR.fits",
+      "shape": [
+        1388
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12607.32049207097,
+        "max": 12607.32049207097,
+        "min": 12318.7519760701,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12318.7519760701
+          },
+          {
+            "index": 347,
+            "value": 12390.946118140973
+          },
+          {
+            "index": 694,
+            "value": 12463.140260211847
+          },
+          {
+            "index": 1041,
+            "value": 12535.334402282722
+          },
+          {
+            "index": 1387,
+            "value": 12607.32049207097
+          }
+        ],
+        "start": 12318.7519760701,
+        "step": 0.208052282624997,
+        "step_median": 0.20805228262543096,
+        "step_std": 7.753533435433356e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1365,
+        "inf_count": 0,
+        "max": 13114.626953125,
+        "mean": 12504.327069024725,
+        "median": 12571.0576171875,
+        "min": 9581.8935546875,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 11007.403515625,
+          "25": 12290.787109375,
+          "5": 11836.847265625,
+          "50": 12571.0576171875,
+          "75": 12806.4140625,
+          "95": 12961.88125,
+          "99": 13027.519609375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 12285.9296875
+          },
+          {
+            "index": 341,
+            "value": 12617.828125
+          },
+          {
+            "index": 682,
+            "value": 12949.171875
+          },
+          {
+            "index": 1023,
+            "value": 12540.724609375
+          },
+          {
+            "index": 1364,
+            "value": 11971.892578125
+          }
+        ],
+        "size": 1365,
+        "std": 396.7139268582682,
+        "sum": 17068406.44921875,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 12336.1181640625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 341,
+            "median": 12681.3486328125,
+            "start_index": 339,
+            "stop_index": 344
+          },
+          {
+            "center_index": 682,
+            "median": 12949.171875,
+            "start_index": 680,
+            "stop_index": 685
+          },
+          {
+            "center_index": 1023,
+            "median": 12540.724609375,
+            "start_index": 1021,
+            "stop_index": 1026
+          },
+          {
+            "center_index": 1364,
+            "median": 11953.099609375,
+            "start_index": 1362,
+            "stop_index": 1365
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.20379020572925,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12054.0767758708,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1365
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m46_fsr1.05_AIR.fits",
+      "shape": [
+        1365
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12332.046616485497,
+        "max": 12332.046616485497,
+        "min": 12054.0767758708,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12054.0767758708
+          },
+          {
+            "index": 341,
+            "value": 12123.569236024476
+          },
+          {
+            "index": 682,
+            "value": 12193.061696178149
+          },
+          {
+            "index": 1023,
+            "value": 12262.554156331824
+          },
+          {
+            "index": 1364,
+            "value": 12332.046616485497
+          }
+        ],
+        "start": 12054.0767758708,
+        "step": 0.20379020572925,
+        "step_median": 0.20379020572909212,
+        "step_std": 5.11347131150554e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1332,
+        "inf_count": 0,
+        "max": 14272.599609375,
+        "mean": 13459.26160071204,
+        "median": 13697.458984375,
+        "min": 6729.01953125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 9247.78900390625,
+          "25": 13241.376953125,
+          "5": 11979.187890625,
+          "50": 13697.458984375,
+          "75": 13998.710205078125,
+          "95": 14150.974658203126,
+          "99": 14200.12556640625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 13274.623046875
+          },
+          {
+            "index": 333,
+            "value": 13848.9658203125
+          },
+          {
+            "index": 666,
+            "value": 14096.82421875
+          },
+          {
+            "index": 999,
+            "value": 13729.2421875
+          },
+          {
+            "index": 1331,
+            "value": 12412.7421875
+          }
+        ],
+        "size": 1332,
+        "std": 880.6724495091458,
+        "sum": 17927736.452148438,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 13258.28125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 333,
+            "median": 13985.947265625,
+            "start_index": 331,
+            "stop_index": 336
+          },
+          {
+            "center_index": 666,
+            "median": 14096.82421875,
+            "start_index": 664,
+            "stop_index": 669
+          },
+          {
+            "center_index": 999,
+            "median": 13710.90234375,
+            "start_index": 997,
+            "stop_index": 1002
+          },
+          {
+            "center_index": 1331,
+            "median": 12503.755859375,
+            "start_index": 1329,
+            "stop_index": 1332
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.199382830303931,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11801.4451657368,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1332
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m47_fsr1.05_AIR.fits",
+      "shape": [
+        1332
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12066.823712871334,
+        "max": 12066.823712871334,
+        "min": 11801.4451657368,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11801.4451657368
+          },
+          {
+            "index": 333,
+            "value": 11867.83964822801
+          },
+          {
+            "index": 666,
+            "value": 11934.234130719218
+          },
+          {
+            "index": 999,
+            "value": 12000.628613210429
+          },
+          {
+            "index": 1331,
+            "value": 12066.823712871334
+          }
+        ],
+        "start": 11801.4451657368,
+        "step": 0.199382830303931,
+        "step_median": 0.19938283030387538,
+        "step_std": 3.1429603139661985e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1317,
+        "inf_count": 0,
+        "max": 15401.580078125,
+        "mean": 14334.855859152549,
+        "median": 14672.7041015625,
+        "min": 3657.91845703125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 8868.207265625,
+          "25": 14119.5,
+          "5": 12062.81640625,
+          "50": 14672.7041015625,
+          "75": 15060.162109375,
+          "95": 15275.08828125,
+          "99": 15361.34484375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 14001.783203125
+          },
+          {
+            "index": 329,
+            "value": 14610.97265625
+          },
+          {
+            "index": 658,
+            "value": 14440.205078125
+          },
+          {
+            "index": 987,
+            "value": 14772.197265625
+          },
+          {
+            "index": 1316,
+            "value": 14078.0
+          }
+        ],
+        "size": 1317,
+        "std": 1255.4710385650808,
+        "sum": 18879005.166503906,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 14001.783203125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 329,
+            "median": 14610.97265625,
+            "start_index": 327,
+            "stop_index": 332
+          },
+          {
+            "center_index": 658,
+            "median": 14727.109375,
+            "start_index": 656,
+            "stop_index": 661
+          },
+          {
+            "center_index": 987,
+            "median": 14772.197265625,
+            "start_index": 985,
+            "stop_index": 990
+          },
+          {
+            "center_index": 1316,
+            "median": 13965.16015625,
+            "start_index": 1314,
+            "stop_index": 1317
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.19551648273157,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11556.404260796,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1317
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m48_fsr1.05_AIR.fits",
+      "shape": [
+        1317
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11813.703952070746,
+        "max": 11813.703952070746,
+        "min": 11556.404260796,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11556.404260796
+          },
+          {
+            "index": 329,
+            "value": 11620.729183614687
+          },
+          {
+            "index": 658,
+            "value": 11685.054106433374
+          },
+          {
+            "index": 987,
+            "value": 11749.379029252059
+          },
+          {
+            "index": 1316,
+            "value": 11813.703952070746
+          }
+        ],
+        "start": 11556.404260796,
+        "step": 0.19551648273157,
+        "step_median": 0.1955164827322733,
+        "step_std": 8.858698853917535e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1269,
+        "inf_count": 0,
+        "max": 16608.482421875,
+        "mean": 12990.272939028187,
+        "median": 14967.5078125,
+        "min": 90.49747467041016,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 733.1523779296874,
+          "25": 12031.302734375,
+          "5": 2810.1604492187503,
+          "50": 14967.5078125,
+          "75": 15781.48828125,
+          "95": 16373.0396484375,
+          "99": 16540.67015625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 14613.896484375
+          },
+          {
+            "index": 317,
+            "value": 16252.2236328125
+          },
+          {
+            "index": 634,
+            "value": 1687.38427734375
+          },
+          {
+            "index": 951,
+            "value": 15694.54296875
+          },
+          {
+            "index": 1268,
+            "value": 14950.052734375
+          }
+        ],
+        "size": 1269,
+        "std": 4245.486312263981,
+        "sum": 16484656.35962677,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 14983.29296875,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 317,
+            "median": 16252.2236328125,
+            "start_index": 315,
+            "stop_index": 320
+          },
+          {
+            "center_index": 634,
+            "median": 4709.4541015625,
+            "start_index": 632,
+            "stop_index": 637
+          },
+          {
+            "center_index": 951,
+            "median": 15694.54296875,
+            "start_index": 949,
+            "stop_index": 954
+          },
+          {
+            "center_index": 1268,
+            "median": 15180.150390625,
+            "start_index": 1266,
+            "stop_index": 1269
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.19157946010857,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11325.2091875107,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1269
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m49_fsr1.05_AIR.fits",
+      "shape": [
+        1269
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11568.131942928367,
+        "max": 11568.131942928367,
+        "min": 11325.2091875107,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11325.2091875107
+          },
+          {
+            "index": 317,
+            "value": 11385.939876365117
+          },
+          {
+            "index": 634,
+            "value": 11446.670565219532
+          },
+          {
+            "index": 951,
+            "value": 11507.40125407395
+          },
+          {
+            "index": 1268,
+            "value": 11568.131942928367
+          }
+        ],
+        "start": 11325.2091875107,
+        "step": 0.19157946010857,
+        "step_median": 0.19157946010818705,
+        "step_std": 7.416236742654402e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1245,
+        "inf_count": 0,
+        "max": 18108.8125,
+        "mean": 13832.199309150665,
+        "median": 15880.921875,
+        "min": 190.45938110351562,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 784.911044921875,
+          "25": 11971.5625,
+          "5": 3103.28125,
+          "50": 15880.921875,
+          "75": 17133.2421875,
+          "95": 17813.979296875,
+          "99": 18018.10578125
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 8592.25390625
+          },
+          {
+            "index": 311,
+            "value": 11721.400390625
+          },
+          {
+            "index": 622,
+            "value": 15671.6064453125
+          },
+          {
+            "index": 933,
+            "value": 16126.9423828125
+          },
+          {
+            "index": 1244,
+            "value": 15473.3359375
+          }
+        ],
+        "size": 1245,
+        "std": 4595.966993300827,
+        "sum": 17221088.139892578,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 9994.64453125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 311,
+            "median": 11721.400390625,
+            "start_index": 309,
+            "stop_index": 314
+          },
+          {
+            "center_index": 622,
+            "median": 15671.6064453125,
+            "start_index": 620,
+            "stop_index": 625
+          },
+          {
+            "center_index": 933,
+            "median": 16126.9423828125,
+            "start_index": 931,
+            "stop_index": 936
+          },
+          {
+            "center_index": 1244,
+            "median": 15514.541015625,
+            "start_index": 1242,
+            "stop_index": 1245
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.187768874783373,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11102.7919993985,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1245
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m50_fsr1.05_AIR.fits",
+      "shape": [
+        1245
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11336.376479629016,
+        "max": 11336.376479629016,
+        "min": 11102.7919993985,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11102.7919993985
+          },
+          {
+            "index": 311,
+            "value": 11161.188119456128
+          },
+          {
+            "index": 622,
+            "value": 11219.584239513757
+          },
+          {
+            "index": 933,
+            "value": 11277.980359571387
+          },
+          {
+            "index": 1244,
+            "value": 11336.376479629016
+          }
+        ],
+        "start": 11102.7919993985,
+        "step": 0.187768874783373,
+        "step_median": 0.1877688747827051,
+        "step_std": 8.76910469159057e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1231,
+        "inf_count": 0,
+        "max": 20030.1640625,
+        "mean": 18026.826576462227,
+        "median": 18605.69921875,
+        "min": 9313.275390625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 11778.3869140625,
+          "25": 17373.0693359375,
+          "5": 14112.18115234375,
+          "50": 18605.69921875,
+          "75": 19322.9892578125,
+          "95": 19816.6318359375,
+          "99": 19915.515625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 18588.8359375
+          },
+          {
+            "index": 307,
+            "value": 14748.837890625
+          },
+          {
+            "index": 615,
+            "value": 19789.365234375
+          },
+          {
+            "index": 923,
+            "value": 19457.662109375
+          },
+          {
+            "index": 1230,
+            "value": 18551.53515625
+          }
+        ],
+        "size": 1231,
+        "std": 1831.2051686876675,
+        "sum": 22191023.515625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 18583.720703125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 307,
+            "median": 14748.837890625,
+            "start_index": 305,
+            "stop_index": 310
+          },
+          {
+            "center_index": 615,
+            "median": 19769.34375,
+            "start_index": 613,
+            "stop_index": 618
+          },
+          {
+            "center_index": 923,
+            "median": 19290.8359375,
+            "start_index": 921,
+            "stop_index": 926
+          },
+          {
+            "center_index": 1230,
+            "median": 18473.677734375,
+            "start_index": 1228,
+            "stop_index": 1231
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.184104656500215,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10887.121018845,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1231
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m51_fsr1.05_AIR.fits",
+      "shape": [
+        1231
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11113.569746340265,
+        "max": 11113.569746340265,
+        "min": 10887.121018845,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10887.121018845
+          },
+          {
+            "index": 307,
+            "value": 10943.641148390567
+          },
+          {
+            "index": 615,
+            "value": 11000.345382592634
+          },
+          {
+            "index": 923,
+            "value": 11057.049616794699
+          },
+          {
+            "index": 1230,
+            "value": 11113.569746340265
+          }
+        ],
+        "start": 10887.121018845,
+        "step": 0.184104656500215,
+        "step_median": 0.18410465650049446,
+        "step_std": 6.559659922830003e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1206,
+        "inf_count": 0,
+        "max": 22252.302734375,
+        "mean": 21414.086800697034,
+        "median": 21595.9248046875,
+        "min": 17702.5703125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 19312.41796875,
+          "25": 21068.1474609375,
+          "5": 19918.09228515625,
+          "50": 21595.9248046875,
+          "75": 21967.93896484375,
+          "95": 22131.2060546875,
+          "99": 22205.309765625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 20700.103515625
+          },
+          {
+            "index": 301,
+            "value": 21839.078125
+          },
+          {
+            "index": 603,
+            "value": 22039.5234375
+          },
+          {
+            "index": 904,
+            "value": 21111.478515625
+          },
+          {
+            "index": 1205,
+            "value": 19533.900390625
+          }
+        ],
+        "size": 1206,
+        "std": 709.0756819698775,
+        "sum": 25825388.681640625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 20700.103515625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 301,
+            "median": 21865.68359375,
+            "start_index": 299,
+            "stop_index": 304
+          },
+          {
+            "center_index": 603,
+            "median": 22053.822265625,
+            "start_index": 601,
+            "stop_index": 606
+          },
+          {
+            "center_index": 904,
+            "median": 21237.109375,
+            "start_index": 902,
+            "stop_index": 907
+          },
+          {
+            "center_index": 1205,
+            "median": 19507.3125,
+            "start_index": 1203,
+            "stop_index": 1206
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.180435535697605,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10680.0922111716,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1206
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m52_fsr1.05_AIR.fits",
+      "shape": [
+        1206
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10897.517031687215,
+        "max": 10897.517031687215,
+        "min": 10680.0922111716,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10680.0922111716
+          },
+          {
+            "index": 301,
+            "value": 10734.40330741658
+          },
+          {
+            "index": 603,
+            "value": 10788.894839197257
+          },
+          {
+            "index": 904,
+            "value": 10843.205935442236
+          },
+          {
+            "index": 1205,
+            "value": 10897.517031687215
+          }
+        ],
+        "start": 10680.0922111716,
+        "step": 0.180435535697605,
+        "step_median": 0.18043553569805226,
+        "step_std": 7.83016510157079e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1182,
+        "inf_count": 0,
+        "max": 24452.78515625,
+        "mean": 23702.33393645569,
+        "median": 23867.0234375,
+        "min": 20329.62890625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 21398.86541015625,
+          "25": 23490.03173828125,
+          "5": 22591.85009765625,
+          "50": 23867.0234375,
+          "75": 24105.14599609375,
+          "95": 24278.60380859375,
+          "99": 24370.27525390625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 23319.734375
+          },
+          {
+            "index": 295,
+            "value": 24264.453125
+          },
+          {
+            "index": 591,
+            "value": 23983.31640625
+          },
+          {
+            "index": 886,
+            "value": 23702.7734375
+          },
+          {
+            "index": 1181,
+            "value": 20329.62890625
+          }
+        ],
+        "size": 1182,
+        "std": 577.4238789242054,
+        "sum": 28016158.712890625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 23260.166015625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 295,
+            "median": 24233.4375,
+            "start_index": 293,
+            "stop_index": 298
+          },
+          {
+            "center_index": 591,
+            "median": 23983.31640625,
+            "start_index": 589,
+            "stop_index": 594
+          },
+          {
+            "center_index": 886,
+            "median": 23661.177734375,
+            "start_index": 884,
+            "stop_index": 889
+          },
+          {
+            "center_index": 1181,
+            "median": 20729.2578125,
+            "start_index": 1179,
+            "stop_index": 1182
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.176994601656012,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10481.0465792562,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1182
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m53_fsr1.05_AIR.fits",
+      "shape": [
+        1182
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10690.07720381195,
+        "max": 10690.07720381195,
+        "min": 10481.0465792562,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10481.0465792562
+          },
+          {
+            "index": 295,
+            "value": 10533.259986744724
+          },
+          {
+            "index": 591,
+            "value": 10585.650388834903
+          },
+          {
+            "index": 886,
+            "value": 10637.863796323427
+          },
+          {
+            "index": 1181,
+            "value": 10690.07720381195
+          }
+        ],
+        "start": 10481.0465792562,
+        "step": 0.176994601656012,
+        "step_median": 0.1769946016556787,
+        "step_std": 7.031869522940888e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1167,
+        "inf_count": 0,
+        "max": 27044.537109375,
+        "mean": 26395.007902875965,
+        "median": 26528.625,
+        "min": 24679.625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 24875.382890625,
+          "25": 26154.90625,
+          "5": 25562.3029296875,
+          "50": 26528.625,
+          "75": 26718.3701171875,
+          "95": 26880.340625,
+          "99": 26959.3071875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 25809.77734375
+          },
+          {
+            "index": 291,
+            "value": 26719.8125
+          },
+          {
+            "index": 583,
+            "value": 26696.458984375
+          },
+          {
+            "index": 875,
+            "value": 26486.3984375
+          },
+          {
+            "index": 1166,
+            "value": 24679.625
+          }
+        ],
+        "size": 1167,
+        "std": 444.99659819075794,
+        "sum": 30802974.22265625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 25916.923828125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 291,
+            "median": 26719.8125,
+            "start_index": 289,
+            "stop_index": 294
+          },
+          {
+            "center_index": 583,
+            "median": 26696.458984375,
+            "start_index": 581,
+            "stop_index": 586
+          },
+          {
+            "center_index": 875,
+            "median": 26364.1796875,
+            "start_index": 873,
+            "stop_index": 878
+          },
+          {
+            "center_index": 1166,
+            "median": 24735.626953125,
+            "start_index": 1164,
+            "stop_index": 1167
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.173783018768597,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10288.0510561775,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1167
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m54_fsr1.05_AIR.fits",
+      "shape": [
+        1167
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10490.682056061685,
+        "max": 10490.682056061685,
+        "min": 10288.0510561775,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10288.0510561775
+          },
+          {
+            "index": 291,
+            "value": 10338.621914639163
+          },
+          {
+            "index": 583,
+            "value": 10389.366556119592
+          },
+          {
+            "index": 875,
+            "value": 10440.111197600023
+          },
+          {
+            "index": 1166,
+            "value": 10490.682056061685
+          }
+        ],
+        "start": 10288.0510561775,
+        "step": 0.173783018768597,
+        "step_median": 0.17378301876851765,
+        "step_std": 3.7200959433375815e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1128,
+        "inf_count": 0,
+        "max": 29916.0390625,
+        "mean": 29041.737058815383,
+        "median": 29115.98828125,
+        "min": 27448.02734375,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 27587.8163671875,
+          "25": 28686.494140625,
+          "5": 28066.721484375,
+          "50": 29115.98828125,
+          "75": 29494.1943359375,
+          "95": 29698.396875,
+          "99": 29790.708359375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 27590.48828125
+          },
+          {
+            "index": 282,
+            "value": 29016.3984375
+          },
+          {
+            "index": 564,
+            "value": 29543.4453125
+          },
+          {
+            "index": 846,
+            "value": 28814.6171875
+          },
+          {
+            "index": 1127,
+            "value": 28292.33984375
+          }
+        ],
+        "size": 1128,
+        "std": 517.9524764131254,
+        "sum": 32759079.40234375,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 27736.3828125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 282,
+            "median": 29118.001953125,
+            "start_index": 280,
+            "stop_index": 285
+          },
+          {
+            "center_index": 564,
+            "median": 29591.47265625,
+            "start_index": 562,
+            "stop_index": 567
+          },
+          {
+            "center_index": 846,
+            "median": 28860.044921875,
+            "start_index": 844,
+            "stop_index": 849
+          },
+          {
+            "center_index": 1127,
+            "median": 28292.33984375,
+            "start_index": 1125,
+            "stop_index": 1128
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.170485177289539,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10105.1504354648,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1128
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m55_fsr1.05_AIR.fits",
+      "shape": [
+        1128
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10297.28723027011,
+        "max": 10297.28723027011,
+        "min": 10105.1504354648,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10105.1504354648
+          },
+          {
+            "index": 282,
+            "value": 10153.22725546045
+          },
+          {
+            "index": 564,
+            "value": 10201.3040754561
+          },
+          {
+            "index": 846,
+            "value": 10249.38089545175
+          },
+          {
+            "index": 1127,
+            "value": 10297.28723027011
+          }
+        ],
+        "start": 10105.1504354648,
+        "step": 0.170485177289539,
+        "step_median": 0.17048517729017476,
+        "step_std": 8.673739032060674e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1126,
+        "inf_count": 0,
+        "max": 32224.7109375,
+        "mean": 29593.795319091365,
+        "median": 30889.08984375,
+        "min": 18095.126953125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 19143.26025390625,
+          "25": 28570.90869140625,
+          "5": 22558.8603515625,
+          "50": 30889.08984375,
+          "75": 31791.61083984375,
+          "95": 31999.0927734375,
+          "99": 32109.08935546875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 31537.8671875
+          },
+          {
+            "index": 281,
+            "value": 31960.1171875
+          },
+          {
+            "index": 563,
+            "value": 29757.953125
+          },
+          {
+            "index": 844,
+            "value": 27550.65234375
+          },
+          {
+            "index": 1125,
+            "value": 29187.966796875
+          }
+        ],
+        "size": 1126,
+        "std": 3061.5137205575506,
+        "sum": 33322613.529296875,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 31329.96484375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 281,
+            "median": 32017.384765625,
+            "start_index": 279,
+            "stop_index": 284
+          },
+          {
+            "center_index": 563,
+            "median": 29870.7109375,
+            "start_index": 561,
+            "stop_index": 566
+          },
+          {
+            "center_index": 844,
+            "median": 27450.37890625,
+            "start_index": 842,
+            "stop_index": 847
+          },
+          {
+            "center_index": 1125,
+            "median": 29187.80078125,
+            "start_index": 1123,
+            "stop_index": 1126
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.16733867748593,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9925.7918226126,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1126
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m56_fsr1.05_AIR.fits",
+      "shape": [
+        1126
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10114.04783478427,
+        "max": 10114.04783478427,
+        "min": 9925.7918226126,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9925.7918226126
+          },
+          {
+            "index": 281,
+            "value": 9972.813990986147
+          },
+          {
+            "index": 563,
+            "value": 10020.003498037178
+          },
+          {
+            "index": 844,
+            "value": 10067.025666410726
+          },
+          {
+            "index": 1125,
+            "value": 10114.04783478427
+          }
+        ],
+        "start": 9925.7918226126,
+        "step": 0.16733867748593,
+        "step_median": 0.16733867748553166,
+        "step_std": 7.518646006325111e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1101,
+        "inf_count": 0,
+        "max": 35927.9296875,
+        "mean": 34976.09550089407,
+        "median": 35297.796875,
+        "min": 22647.890625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 28184.587890625,
+          "25": 35013.62890625,
+          "5": 33030.01953125,
+          "50": 35297.796875,
+          "75": 35512.5,
+          "95": 35747.89453125,
+          "99": 35826.984375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 28197.55078125
+          },
+          {
+            "index": 275,
+            "value": 35332.0546875
+          },
+          {
+            "index": 550,
+            "value": 34445.3984375
+          },
+          {
+            "index": 825,
+            "value": 34867.66015625
+          },
+          {
+            "index": 1100,
+            "value": 35338.6953125
+          }
+        ],
+        "size": 1101,
+        "std": 1297.9504027652642,
+        "sum": 38508681.146484375,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 28197.55078125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 275,
+            "median": 35332.0546875,
+            "start_index": 273,
+            "stop_index": 278
+          },
+          {
+            "center_index": 550,
+            "median": 35001.234375,
+            "start_index": 548,
+            "stop_index": 553
+          },
+          {
+            "center_index": 825,
+            "median": 34867.66015625,
+            "start_index": 823,
+            "stop_index": 828
+          },
+          {
+            "center_index": 1100,
+            "median": 35196.37109375,
+            "start_index": 1098,
+            "stop_index": 1101
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.164368996227023,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9753.61581750591,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1101
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m57_fsr1.05_AIR.fits",
+      "shape": [
+        1101
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9934.421713355636,
+        "max": 9934.421713355636,
+        "min": 9753.61581750591,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9753.61581750591
+          },
+          {
+            "index": 275,
+            "value": 9798.817291468342
+          },
+          {
+            "index": 550,
+            "value": 9844.018765430772
+          },
+          {
+            "index": 825,
+            "value": 9889.220239393204
+          },
+          {
+            "index": 1100,
+            "value": 9934.421713355636
+          }
+        ],
+        "start": 9753.61581750591,
+        "step": 0.164368996227023,
+        "step_median": 0.1643689962274948,
+        "step_std": 7.969640260488713e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1088,
+        "inf_count": 0,
+        "max": 39516.9140625,
+        "mean": 36596.174416934744,
+        "median": 38144.138671875,
+        "min": 18670.80078125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 22334.92921875,
+          "25": 35992.888671875,
+          "5": 28613.2556640625,
+          "50": 38144.138671875,
+          "75": 38833.0517578125,
+          "95": 39172.637109375,
+          "99": 39315.7398046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 35746.7890625
+          },
+          {
+            "index": 272,
+            "value": 37825.140625
+          },
+          {
+            "index": 544,
+            "value": 38970.71875
+          },
+          {
+            "index": 816,
+            "value": 39179.17578125
+          },
+          {
+            "index": 1087,
+            "value": 37190.1875
+          }
+        ],
+        "size": 1088,
+        "std": 3631.805811274457,
+        "sum": 39816637.765625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 35533.67578125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 272,
+            "median": 37689.671875,
+            "start_index": 270,
+            "stop_index": 275
+          },
+          {
+            "center_index": 544,
+            "median": 39054.31640625,
+            "start_index": 542,
+            "stop_index": 547
+          },
+          {
+            "center_index": 816,
+            "median": 39048.0625,
+            "start_index": 814,
+            "stop_index": 819
+          },
+          {
+            "center_index": 1087,
+            "median": 37018.2734375,
+            "start_index": 1085,
+            "stop_index": 1088
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.161412870494629,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9586.48824215831,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1088
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m58_fsr1.05_AIR.fits",
+      "shape": [
+        1088
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9761.94403238597,
+        "max": 9761.94403238597,
+        "min": 9586.48824215831,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9586.48824215831
+          },
+          {
+            "index": 272,
+            "value": 9630.392542932848
+          },
+          {
+            "index": 544,
+            "value": 9674.296843707389
+          },
+          {
+            "index": 816,
+            "value": 9718.201144481927
+          },
+          {
+            "index": 1087,
+            "value": 9761.94403238597
+          }
+        ],
+        "start": 9586.48824215831,
+        "step": 0.161412870494629,
+        "step_median": 0.16141287049504172,
+        "step_std": 7.62234750839062e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1074,
+        "inf_count": 0,
+        "max": 42287.0859375,
+        "mean": 33203.66710061867,
+        "median": 35431.201171875,
+        "min": 2495.932861328125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 5959.55939453125,
+          "25": 29209.85791015625,
+          "5": 14964.40615234375,
+          "50": 35431.201171875,
+          "75": 39769.9697265625,
+          "95": 41704.301953125,
+          "99": 42093.973046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 40733.015625
+          },
+          {
+            "index": 268,
+            "value": 38575.7109375
+          },
+          {
+            "index": 537,
+            "value": 40450.16015625
+          },
+          {
+            "index": 805,
+            "value": 30049.82421875
+          },
+          {
+            "index": 1073,
+            "value": 35028.2734375
+          }
+        ],
+        "size": 1074,
+        "std": 8391.700008296355,
+        "sum": 35660738.46606445,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 40513.71875,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 268,
+            "median": 40284.046875,
+            "start_index": 266,
+            "stop_index": 271
+          },
+          {
+            "center_index": 537,
+            "median": 40194.1015625,
+            "start_index": 535,
+            "stop_index": 540
+          },
+          {
+            "center_index": 805,
+            "median": 30049.82421875,
+            "start_index": 803,
+            "stop_index": 808
+          },
+          {
+            "center_index": 1073,
+            "median": 35028.2734375,
+            "start_index": 1071,
+            "stop_index": 1074
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.158532791239092,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9424.45986117665,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1074
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m59_fsr1.05_AIR.fits",
+      "shape": [
+        1074
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9594.565546176196,
+        "max": 9594.565546176196,
+        "min": 9424.45986117665,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9424.45986117665
+          },
+          {
+            "index": 268,
+            "value": 9466.946649228727
+          },
+          {
+            "index": 537,
+            "value": 9509.591970072042
+          },
+          {
+            "index": 805,
+            "value": 9552.07875812412
+          },
+          {
+            "index": 1073,
+            "value": 9594.565546176196
+          }
+        ],
+        "start": 9424.45986117665,
+        "step": 0.158532791239092,
+        "step_median": 0.15853279123984976,
+        "step_std": 8.967499793499216e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1034,
+        "inf_count": 0,
+        "max": 47171.4765625,
+        "mean": 39002.58976536056,
+        "median": 43546.29296875,
+        "min": 3461.53271484375,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 6841.514296875,
+          "25": 37017.7001953125,
+          "5": 14768.715478515625,
+          "50": 43546.29296875,
+          "75": 45282.404296875,
+          "95": 46424.819140625,
+          "99": 46842.131015625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 44994.328125
+          },
+          {
+            "index": 258,
+            "value": 43285.875
+          },
+          {
+            "index": 517,
+            "value": 45042.234375
+          },
+          {
+            "index": 775,
+            "value": 40577.40625
+          },
+          {
+            "index": 1033,
+            "value": 45918.875
+          }
+        ],
+        "size": 1034,
+        "std": 9910.2224187167,
+        "sum": 40328677.81738281,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 44946.3359375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 258,
+            "median": 43285.875,
+            "start_index": 256,
+            "stop_index": 261
+          },
+          {
+            "center_index": 517,
+            "median": 45042.234375,
+            "start_index": 515,
+            "stop_index": 520
+          },
+          {
+            "center_index": 775,
+            "median": 40577.40625,
+            "start_index": 773,
+            "stop_index": 778
+          },
+          {
+            "center_index": 1033,
+            "median": 45434.25,
+            "start_index": 1031,
+            "stop_index": 1034
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.155831937195421,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9271.21912249884,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1034
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m60_fsr1.05_AIR.fits",
+      "shape": [
+        1034
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9432.19351362171,
+        "max": 9432.19351362171,
+        "min": 9271.21912249884,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9271.21912249884
+          },
+          {
+            "index": 258,
+            "value": 9311.423762295259
+          },
+          {
+            "index": 517,
+            "value": 9351.784234028873
+          },
+          {
+            "index": 775,
+            "value": 9391.988873825292
+          },
+          {
+            "index": 1033,
+            "value": 9432.19351362171
+          }
+        ],
+        "start": 9271.21912249884,
+        "step": 0.155831937195421,
+        "step_median": 0.1558319371961261,
+        "step_std": 8.86057076164152e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1039,
+        "inf_count": 0,
+        "max": 51792.96875,
+        "mean": 45617.37819192132,
+        "median": 47466.859375,
+        "min": 29235.0390625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 30467.007890625,
+          "25": 42349.51953125,
+          "5": 33846.86484375,
+          "50": 47466.859375,
+          "75": 50057.6953125,
+          "95": 51246.086328125,
+          "99": 51538.40046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 50553.7265625
+          },
+          {
+            "index": 259,
+            "value": 50813.015625
+          },
+          {
+            "index": 519,
+            "value": 47252.0546875
+          },
+          {
+            "index": 779,
+            "value": 37551.140625
+          },
+          {
+            "index": 1038,
+            "value": 34511.78125
+          }
+        ],
+        "size": 1039,
+        "std": 5536.930031779965,
+        "sum": 47396455.94140625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 50793.7109375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 259,
+            "median": 50813.015625,
+            "start_index": 257,
+            "stop_index": 262
+          },
+          {
+            "center_index": 519,
+            "median": 47387.6484375,
+            "start_index": 517,
+            "stop_index": 522
+          },
+          {
+            "center_index": 779,
+            "median": 38491.9375,
+            "start_index": 777,
+            "stop_index": 782
+          },
+          {
+            "center_index": 1038,
+            "median": 42637.484375,
+            "start_index": 1036,
+            "stop_index": 1039
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.153162563138058,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9119.70741076317,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1039
+      },
+      "path": "4_Ari_sum/AIR_flux/fsr1.05/4_Ari_sum_m61_fsr1.05_AIR.fits",
+      "shape": [
+        1039
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9278.690151300474,
+        "max": 9278.690151300474,
+        "min": 9119.70741076317,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9119.70741076317
+          },
+          {
+            "index": 259,
+            "value": 9159.376514615928
+          },
+          {
+            "index": 519,
+            "value": 9199.198781031822
+          },
+          {
+            "index": 779,
+            "value": 9239.021047447717
+          },
+          {
+            "index": 1038,
+            "value": 9278.690151300474
+          }
+        ],
+        "start": 9119.70741076317,
+        "step": 0.153162563138058,
+        "step_median": 0.15316256313781196,
+        "step_std": 6.213481387947486e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 28692,
+        "inf_count": 0,
+        "max": 6.0230631828308105,
+        "mean": 0.9398374075165892,
+        "median": 0.9944530427455902,
+        "min": -22.50371742248535,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.17634834304451943,
+          "25": 0.9639298915863037,
+          "5": 0.64899922311306,
+          "50": 0.9944530427455902,
+          "75": 0.9998566508293152,
+          "95": 1.006379896402359,
+          "99": 1.0264742624759675
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0531350374221802
+          },
+          {
+            "index": 7173,
+            "value": 1.0021706819534302
+          },
+          {
+            "index": 14346,
+            "value": 0.9441797137260437
+          },
+          {
+            "index": 21519,
+            "value": 0.998290479183197
+          },
+          {
+            "index": 28691,
+            "value": -0.26575911045074463
+          }
+        ],
+        "size": 28692,
+        "std": 0.25982624071418564,
+        "sum": 26965.814896465978,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0530134439468384,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 7173,
+            "median": 1.0021706819534302,
+            "start_index": 7171,
+            "stop_index": 7176
+          },
+          {
+            "center_index": 14346,
+            "median": 0.9441797137260437,
+            "start_index": 14344,
+            "stop_index": 14349
+          },
+          {
+            "center_index": 21519,
+            "median": 0.998290479183197,
+            "start_index": 21517,
+            "stop_index": 21522
+          },
+          {
+            "center_index": 28691,
+            "median": -0.18075309693813324,
+            "start_index": 28689,
+            "stop_index": 28692
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.1531608480229,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9119.70703125001,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 28692
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_fsr1.05_AIR_norm_comb.fits",
+      "shape": [
+        28692
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13514.044921875033,
+        "max": 13514.044921875033,
+        "min": 9119.70703125001,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9119.70703125001
+          },
+          {
+            "index": 7173,
+            "value": 10218.329794118272
+          },
+          {
+            "index": 14346,
+            "value": 11316.952556986533
+          },
+          {
+            "index": 21519,
+            "value": 12415.575319854794
+          },
+          {
+            "index": 28691,
+            "value": 13514.044921875033
+          }
+        ],
+        "start": 9119.70703125001,
+        "step": 0.1531608480229,
+        "step_median": 0.1531608480236173,
+        "step_std": 9.019627913717004e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1503,
+        "inf_count": 0,
+        "max": 1.3739925622940063,
+        "mean": 0.8628918484035515,
+        "median": 0.9741634726524353,
+        "min": -0.4304264783859253,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -0.1364423942565918,
+          "25": 0.8176759779453278,
+          "5": 0.3289551019668579,
+          "50": 0.9741634726524353,
+          "75": 1.004616379737854,
+          "95": 1.023898434638977,
+          "99": 1.100060124397278
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.8464686870574951
+          },
+          {
+            "index": 375,
+            "value": 1.0096803903579712
+          },
+          {
+            "index": 751,
+            "value": 1.0092204809188843
+          },
+          {
+            "index": 1127,
+            "value": 1.0286388397216797
+          },
+          {
+            "index": 1502,
+            "value": -0.2729581594467163
+          }
+        ],
+        "size": 1503,
+        "std": 0.24369373255119317,
+        "sum": 1296.926448150538,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.96893709897995,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 375,
+            "median": 1.0073227882385254,
+            "start_index": 373,
+            "stop_index": 378
+          },
+          {
+            "center_index": 751,
+            "median": 1.0092204809188843,
+            "start_index": 749,
+            "stop_index": 754
+          },
+          {
+            "center_index": 1127,
+            "median": 1.0277574062347412,
+            "start_index": 1125,
+            "stop_index": 1130
+          },
+          {
+            "center_index": 1502,
+            "median": -0.19829429686069489,
+            "start_index": 1500,
+            "stop_index": 1503
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.222444582710918,
+        "CRPIX1": 1.0,
+        "CRVAL1": 13179.9330998032,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1503
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m42_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1503
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13514.044863034998,
+        "max": 13514.044863034998,
+        "min": 13179.9330998032,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 13179.9330998032
+          },
+          {
+            "index": 375,
+            "value": 13263.349818319793
+          },
+          {
+            "index": 751,
+            "value": 13346.9889814191
+          },
+          {
+            "index": 1127,
+            "value": 13430.628144518405
+          },
+          {
+            "index": 1502,
+            "value": 13514.044863034998
+          }
+        ],
+        "start": 13179.9330998032,
+        "step": 0.222444582710918,
+        "step_median": 0.2224445827105228,
+        "step_std": 7.498470674615173e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1423,
+        "inf_count": 0,
+        "max": 1.0174169540405273,
+        "mean": 0.9760635392982526,
+        "median": 0.9943099617958069,
+        "min": 0.4227278530597687,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.6808730721473694,
+          "25": 0.9798784255981445,
+          "5": 0.8816131472587585,
+          "50": 0.9943099617958069,
+          "75": 0.9994941055774689,
+          "95": 1.004460871219635,
+          "99": 1.0097497034072875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9861146211624146
+          },
+          {
+            "index": 355,
+            "value": 0.9786655306816101
+          },
+          {
+            "index": 711,
+            "value": 0.9645792841911316
+          },
+          {
+            "index": 1067,
+            "value": 0.9926929473876953
+          },
+          {
+            "index": 1422,
+            "value": 0.9727053046226501
+          }
+        ],
+        "size": 1423,
+        "std": 0.05723261201539516,
+        "sum": 1388.9384164214134,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0002963542938232,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 355,
+            "median": 0.9894715547561646,
+            "start_index": 353,
+            "stop_index": 358
+          },
+          {
+            "center_index": 711,
+            "median": 0.9645792841911316,
+            "start_index": 709,
+            "stop_index": 714
+          },
+          {
+            "center_index": 1067,
+            "median": 0.9926929473876953,
+            "start_index": 1065,
+            "stop_index": 1070
+          },
+          {
+            "center_index": 1422,
+            "median": 0.9737085103988647,
+            "start_index": 1420,
+            "stop_index": 1423
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.21746673193894,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12885.8059644196,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1423
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m43_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1423
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13195.043657236773,
+        "max": 13195.043657236773,
+        "min": 12885.8059644196,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12885.8059644196
+          },
+          {
+            "index": 355,
+            "value": 12963.006654257924
+          },
+          {
+            "index": 711,
+            "value": 13040.424810828186
+          },
+          {
+            "index": 1067,
+            "value": 13117.842967398448
+          },
+          {
+            "index": 1422,
+            "value": 13195.043657236773
+          }
+        ],
+        "start": 12885.8059644196,
+        "step": 0.21746673193894,
+        "step_median": 0.21746673193956667,
+        "step_std": 8.644434121311479e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1444,
+        "inf_count": 0,
+        "max": 1.010928988456726,
+        "mean": 0.9520870295876942,
+        "median": 0.994228184223175,
+        "min": 0.33631187677383423,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.5555250018835067,
+          "25": 0.9626784771680832,
+          "5": 0.7215249627828598,
+          "50": 0.994228184223175,
+          "75": 0.9992671310901642,
+          "95": 1.0038607716560364,
+          "99": 1.0062836301326752
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9948727488517761
+          },
+          {
+            "index": 361,
+            "value": 1.0040696859359741
+          },
+          {
+            "index": 722,
+            "value": 0.9965012669563293
+          },
+          {
+            "index": 1083,
+            "value": 0.9610736966133118
+          },
+          {
+            "index": 1443,
+            "value": 0.9852023124694824
+          }
+        ],
+        "size": 1444,
+        "std": 0.09716214604022387,
+        "sum": 1374.8136707246304,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.001591682434082,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 361,
+            "median": 0.9979012608528137,
+            "start_index": 359,
+            "stop_index": 364
+          },
+          {
+            "center_index": 722,
+            "median": 0.9974427223205566,
+            "start_index": 720,
+            "stop_index": 725
+          },
+          {
+            "center_index": 1083,
+            "median": 0.9589628577232361,
+            "start_index": 1081,
+            "stop_index": 1086
+          },
+          {
+            "center_index": 1443,
+            "median": 0.9852023124694824,
+            "start_index": 1441,
+            "stop_index": 1444
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.212704536480577,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12593.3404943131,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1444
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m44_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1444
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12900.273140454574,
+        "max": 12900.273140454574,
+        "min": 12593.3404943131,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12593.3404943131
+          },
+          {
+            "index": 361,
+            "value": 12670.126831982589
+          },
+          {
+            "index": 722,
+            "value": 12746.913169652078
+          },
+          {
+            "index": 1083,
+            "value": 12823.699507321566
+          },
+          {
+            "index": 1443,
+            "value": 12900.273140454574
+          }
+        ],
+        "start": 12593.3404943131,
+        "step": 0.212704536480577,
+        "step_median": 0.21270453648139664,
+        "step_std": 9.050177769972554e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1388,
+        "inf_count": 0,
+        "max": 1.0202733278274536,
+        "mean": 0.9936652184821,
+        "median": 0.9981638789176941,
+        "min": 0.6135095953941345,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.871470999121666,
+          "25": 0.9945069551467896,
+          "5": 0.9771568775177002,
+          "50": 0.9981638789176941,
+          "75": 1.0011822581291199,
+          "95": 1.0059946715831756,
+          "99": 1.0092887210845947
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.002463459968567
+          },
+          {
+            "index": 347,
+            "value": 1.0038187503814697
+          },
+          {
+            "index": 694,
+            "value": 0.9716183543205261
+          },
+          {
+            "index": 1041,
+            "value": 0.9942705035209656
+          },
+          {
+            "index": 1387,
+            "value": 0.9786087870597839
+          }
+        ],
+        "size": 1388,
+        "std": 0.02654602674328954,
+        "sum": 1379.2073232531548,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0071009397506714,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 347,
+            "median": 1.0017776489257812,
+            "start_index": 345,
+            "stop_index": 350
+          },
+          {
+            "center_index": 694,
+            "median": 0.9716183543205261,
+            "start_index": 692,
+            "stop_index": 697
+          },
+          {
+            "center_index": 1041,
+            "median": 0.9942705035209656,
+            "start_index": 1039,
+            "stop_index": 1044
+          },
+          {
+            "center_index": 1387,
+            "median": 1.0037237405776978,
+            "start_index": 1385,
+            "stop_index": 1388
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.208052282624997,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12318.7519760701,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1388
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m45_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1388
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12607.32049207097,
+        "max": 12607.32049207097,
+        "min": 12318.7519760701,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12318.7519760701
+          },
+          {
+            "index": 347,
+            "value": 12390.946118140973
+          },
+          {
+            "index": 694,
+            "value": 12463.140260211847
+          },
+          {
+            "index": 1041,
+            "value": 12535.334402282722
+          },
+          {
+            "index": 1387,
+            "value": 12607.32049207097
+          }
+        ],
+        "start": 12318.7519760701,
+        "step": 0.208052282624997,
+        "step_median": 0.20805228262543096,
+        "step_std": 7.753533435433356e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1365,
+        "inf_count": 0,
+        "max": 1.0133289098739624,
+        "mean": 0.987766611226749,
+        "median": 0.9954490661621094,
+        "min": 0.7594255805015564,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.8797195386886597,
+          "25": 0.9850367307662964,
+          "5": 0.9432659149169922,
+          "50": 0.9954490661621094,
+          "75": 0.9999735355377197,
+          "95": 1.0057258367538453,
+          "99": 1.009229893684387
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9954490661621094
+          },
+          {
+            "index": 341,
+            "value": 0.9791178703308105
+          },
+          {
+            "index": 682,
+            "value": 0.9968851208686829
+          },
+          {
+            "index": 1023,
+            "value": 0.9984455108642578
+          },
+          {
+            "index": 1364,
+            "value": 1.0027393102645874
+          }
+        ],
+        "size": 1365,
+        "std": 0.024139350743705445,
+        "sum": 1348.3014243245125,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9993311762809753,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 341,
+            "median": 0.9839388132095337,
+            "start_index": 339,
+            "stop_index": 344
+          },
+          {
+            "center_index": 682,
+            "median": 0.9965722560882568,
+            "start_index": 680,
+            "stop_index": 685
+          },
+          {
+            "center_index": 1023,
+            "median": 0.9984455108642578,
+            "start_index": 1021,
+            "stop_index": 1026
+          },
+          {
+            "center_index": 1364,
+            "median": 1.0013411045074463,
+            "start_index": 1362,
+            "stop_index": 1365
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.20379020572925,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12054.0767758708,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1365
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m46_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1365
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12332.046616485497,
+        "max": 12332.046616485497,
+        "min": 12054.0767758708,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12054.0767758708
+          },
+          {
+            "index": 341,
+            "value": 12123.569236024476
+          },
+          {
+            "index": 682,
+            "value": 12193.061696178149
+          },
+          {
+            "index": 1023,
+            "value": 12262.554156331824
+          },
+          {
+            "index": 1364,
+            "value": 12332.046616485497
+          }
+        ],
+        "start": 12054.0767758708,
+        "step": 0.20379020572925,
+        "step_median": 0.20379020572909212,
+        "step_std": 5.11347131150554e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1332,
+        "inf_count": 0,
+        "max": 1.0139120817184448,
+        "mean": 0.973517561549539,
+        "median": 0.99332195520401,
+        "min": 0.49473774433135986,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.6742737650871277,
+          "25": 0.9728740751743317,
+          "5": 0.8733851253986359,
+          "50": 0.99332195520401,
+          "75": 0.9994349479675293,
+          "95": 1.0044060945510864,
+          "99": 1.0084686815738677
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0012753009796143
+          },
+          {
+            "index": 333,
+            "value": 0.9835005402565002
+          },
+          {
+            "index": 666,
+            "value": 0.9982927441596985
+          },
+          {
+            "index": 999,
+            "value": 0.9960401654243469
+          },
+          {
+            "index": 1331,
+            "value": 0.9557479023933411
+          }
+        ],
+        "size": 1332,
+        "std": 0.05811350179356856,
+        "sum": 1296.725391983986,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9985451102256775,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 333,
+            "median": 0.9932483434677124,
+            "start_index": 331,
+            "stop_index": 336
+          },
+          {
+            "center_index": 666,
+            "median": 0.9982927441596985,
+            "start_index": 664,
+            "stop_index": 669
+          },
+          {
+            "center_index": 999,
+            "median": 0.9946168065071106,
+            "start_index": 997,
+            "stop_index": 1002
+          },
+          {
+            "center_index": 1331,
+            "median": 0.9627960920333862,
+            "start_index": 1329,
+            "stop_index": 1332
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.199382830303931,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11801.4451657368,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1332
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m47_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1332
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12066.823712871334,
+        "max": 12066.823712871334,
+        "min": 11801.4451657368,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11801.4451657368
+          },
+          {
+            "index": 333,
+            "value": 11867.83964822801
+          },
+          {
+            "index": 666,
+            "value": 11934.234130719218
+          },
+          {
+            "index": 999,
+            "value": 12000.628613210429
+          },
+          {
+            "index": 1331,
+            "value": 12066.823712871334
+          }
+        ],
+        "start": 11801.4451657368,
+        "step": 0.199382830303931,
+        "step_median": 0.19938283030387538,
+        "step_std": 3.1429603139661985e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1317,
+        "inf_count": 0,
+        "max": 1.0196775197982788,
+        "mean": 0.9593682672797321,
+        "median": 0.9878543615341187,
+        "min": 0.2495858520269394,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.5863633060455322,
+          "25": 0.9596217274665833,
+          "5": 0.8054463863372803,
+          "50": 0.9878543615341187,
+          "75": 0.9971714615821838,
+          "95": 1.0038378953933715,
+          "99": 1.0084836196899414
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0046377182006836
+          },
+          {
+            "index": 329,
+            "value": 0.9596343636512756
+          },
+          {
+            "index": 658,
+            "value": 0.9462335705757141
+          },
+          {
+            "index": 987,
+            "value": 0.9832630753517151
+          },
+          {
+            "index": 1316,
+            "value": 0.9992138743400574
+          }
+        ],
+        "size": 1317,
+        "std": 0.0805051018174718,
+        "sum": 1263.4880080074072,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0038787126541138,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 329,
+            "median": 0.9596343636512756,
+            "start_index": 327,
+            "stop_index": 332
+          },
+          {
+            "center_index": 658,
+            "median": 0.9649951457977295,
+            "start_index": 656,
+            "stop_index": 661
+          },
+          {
+            "center_index": 987,
+            "median": 0.9832630753517151,
+            "start_index": 985,
+            "stop_index": 990
+          },
+          {
+            "center_index": 1316,
+            "median": 0.9914083480834961,
+            "start_index": 1314,
+            "stop_index": 1317
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.19551648273157,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11556.404260796,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1317
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m48_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1317
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11813.703952070746,
+        "max": 11813.703952070746,
+        "min": 11556.404260796,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11556.404260796
+          },
+          {
+            "index": 329,
+            "value": 11620.729183614687
+          },
+          {
+            "index": 658,
+            "value": 11685.054106433374
+          },
+          {
+            "index": 987,
+            "value": 11749.379029252059
+          },
+          {
+            "index": 1316,
+            "value": 11813.703952070746
+          }
+        ],
+        "start": 11556.404260796,
+        "step": 0.19551648273157,
+        "step_median": 0.1955164827322733,
+        "step_std": 8.858698853917535e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1269,
+        "inf_count": 0,
+        "max": 1.0743556022644043,
+        "mean": 0.8183857435833918,
+        "median": 0.9481167793273926,
+        "min": 0.005694129038602114,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.04665384560823441,
+          "25": 0.7604947686195374,
+          "5": 0.17897295057773593,
+          "50": 0.9481167793273926,
+          "75": 0.9916372299194336,
+          "95": 1.0054885864257812,
+          "99": 1.0170092344284056
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0392388105392456
+          },
+          {
+            "index": 317,
+            "value": 0.9880177974700928
+          },
+          {
+            "index": 634,
+            "value": 0.10713793337345123
+          },
+          {
+            "index": 951,
+            "value": 0.9905954003334045
+          },
+          {
+            "index": 1268,
+            "value": 0.968689501285553
+          }
+        ],
+        "size": 1269,
+        "std": 0.26443495551691404,
+        "sum": 1038.5315086073242,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.060171127319336,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 317,
+            "median": 0.9880177974700928,
+            "start_index": 315,
+            "stop_index": 320
+          },
+          {
+            "center_index": 634,
+            "median": 0.29913458228111267,
+            "start_index": 632,
+            "stop_index": 637
+          },
+          {
+            "center_index": 951,
+            "median": 0.9905954003334045,
+            "start_index": 949,
+            "stop_index": 954
+          },
+          {
+            "center_index": 1268,
+            "median": 0.9853458404541016,
+            "start_index": 1266,
+            "stop_index": 1269
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.19157946010857,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11325.2091875107,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1269
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m49_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1269
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11568.131942928367,
+        "max": 11568.131942928367,
+        "min": 11325.2091875107,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11325.2091875107
+          },
+          {
+            "index": 317,
+            "value": 11385.939876365117
+          },
+          {
+            "index": 634,
+            "value": 11446.670565219532
+          },
+          {
+            "index": 951,
+            "value": 11507.40125407395
+          },
+          {
+            "index": 1268,
+            "value": 11568.131942928367
+          }
+        ],
+        "start": 11325.2091875107,
+        "step": 0.19157946010857,
+        "step_median": 0.19157946010818705,
+        "step_std": 7.416236742654402e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1245,
+        "inf_count": 0,
+        "max": 3.845062255859375,
+        "mean": 0.7458012676719262,
+        "median": 0.9156439900398254,
+        "min": -38.39313507080078,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -1.038745756149292,
+          "25": 0.6946374177932739,
+          "5": 0.1423472195863724,
+          "50": 0.9156439900398254,
+          "75": 0.9856025576591492,
+          "95": 1.0059812545776368,
+          "99": 1.3135232686996416
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.48518848419189453
+          },
+          {
+            "index": 311,
+            "value": 0.6784419417381287
+          },
+          {
+            "index": 622,
+            "value": 0.8814876675605774
+          },
+          {
+            "index": 933,
+            "value": 0.962229311466217
+          },
+          {
+            "index": 1244,
+            "value": -0.7990520000457764
+          }
+        ],
+        "size": 1245,
+        "std": 1.2008464921257551,
+        "sum": 928.5225782515481,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.5646653771400452,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 311,
+            "median": 0.6784419417381287,
+            "start_index": 309,
+            "stop_index": 314
+          },
+          {
+            "center_index": 622,
+            "median": 0.8814876675605774,
+            "start_index": 620,
+            "stop_index": 625
+          },
+          {
+            "center_index": 933,
+            "median": 0.962229311466217,
+            "start_index": 931,
+            "stop_index": 936
+          },
+          {
+            "center_index": 1244,
+            "median": -0.867023229598999,
+            "start_index": 1242,
+            "stop_index": 1245
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.187768874783373,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11102.7919993985,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1245
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m50_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1245
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11336.376479629016,
+        "max": 11336.376479629016,
+        "min": 11102.7919993985,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11102.7919993985
+          },
+          {
+            "index": 311,
+            "value": 11161.188119456128
+          },
+          {
+            "index": 622,
+            "value": 11219.584239513757
+          },
+          {
+            "index": 933,
+            "value": 11277.980359571387
+          },
+          {
+            "index": 1244,
+            "value": 11336.376479629016
+          }
+        ],
+        "start": 11102.7919993985,
+        "step": 0.187768874783373,
+        "step_median": 0.1877688747827051,
+        "step_std": 8.76910469159057e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1231,
+        "inf_count": 0,
+        "max": 1.015554428100586,
+        "mean": 0.9679089481030704,
+        "median": 0.9892725944519043,
+        "min": 0.5039809346199036,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.7311637759208679,
+          "25": 0.9620690643787384,
+          "5": 0.8578657507896423,
+          "50": 0.9892725944519043,
+          "75": 0.9981858432292938,
+          "95": 1.0034105777740479,
+          "99": 1.00616352558136
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.001808762550354
+          },
+          {
+            "index": 307,
+            "value": 0.9557226896286011
+          },
+          {
+            "index": 615,
+            "value": 1.0040339231491089
+          },
+          {
+            "index": 923,
+            "value": 0.9926385283470154
+          },
+          {
+            "index": 1230,
+            "value": 1.0019060373306274
+          }
+        ],
+        "size": 1231,
+        "std": 0.056538341118923426,
+        "sum": 1191.4959151148796,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.000440239906311,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 307,
+            "median": 0.9557226896286011,
+            "start_index": 305,
+            "stop_index": 310
+          },
+          {
+            "center_index": 615,
+            "median": 1.002592921257019,
+            "start_index": 613,
+            "stop_index": 618
+          },
+          {
+            "center_index": 923,
+            "median": 0.9842290878295898,
+            "start_index": 921,
+            "stop_index": 926
+          },
+          {
+            "center_index": 1230,
+            "median": 0.9979926347732544,
+            "start_index": 1228,
+            "stop_index": 1231
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.184104656500215,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10887.121018845,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1231
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m51_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1231
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11113.569746340265,
+        "max": 11113.569746340265,
+        "min": 10887.121018845,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10887.121018845
+          },
+          {
+            "index": 307,
+            "value": 10943.641148390567
+          },
+          {
+            "index": 615,
+            "value": 11000.345382592634
+          },
+          {
+            "index": 923,
+            "value": 11057.049616794699
+          },
+          {
+            "index": 1230,
+            "value": 11113.569746340265
+          }
+        ],
+        "start": 10887.121018845,
+        "step": 0.184104656500215,
+        "step_median": 0.18410465650049446,
+        "step_std": 6.559659922830003e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1206,
+        "inf_count": 0,
+        "max": 1.0100181102752686,
+        "mean": 0.9900577645100171,
+        "median": 0.9969737827777863,
+        "min": 0.8323075771331787,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.9179726660251617,
+          "25": 0.9876411408185959,
+          "5": 0.9555287510156631,
+          "50": 0.9969737827777863,
+          "75": 1.0001820623874664,
+          "95": 1.0039385259151459,
+          "99": 1.0061812937259673
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0004112720489502
+          },
+          {
+            "index": 301,
+            "value": 0.9990099668502808
+          },
+          {
+            "index": 603,
+            "value": 0.9998164772987366
+          },
+          {
+            "index": 904,
+            "value": 0.9484230279922485
+          },
+          {
+            "index": 1205,
+            "value": 1.00418221950531
+          }
+        ],
+        "size": 1206,
+        "std": 0.018120304947268327,
+        "sum": 1194.0096639990807,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9993415474891663,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 301,
+            "median": 1.0003125667572021,
+            "start_index": 299,
+            "stop_index": 304
+          },
+          {
+            "center_index": 603,
+            "median": 1.0005313158035278,
+            "start_index": 601,
+            "stop_index": 606
+          },
+          {
+            "center_index": 904,
+            "median": 0.954587996006012,
+            "start_index": 902,
+            "stop_index": 907
+          },
+          {
+            "center_index": 1205,
+            "median": 1.0015949010849,
+            "start_index": 1203,
+            "stop_index": 1206
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.180435535697605,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10680.0922111716,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1206
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m52_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1206
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10897.517031687215,
+        "max": 10897.517031687215,
+        "min": 10680.0922111716,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10680.0922111716
+          },
+          {
+            "index": 301,
+            "value": 10734.40330741658
+          },
+          {
+            "index": 603,
+            "value": 10788.894839197257
+          },
+          {
+            "index": 904,
+            "value": 10843.205935442236
+          },
+          {
+            "index": 1205,
+            "value": 10897.517031687215
+          }
+        ],
+        "start": 10680.0922111716,
+        "step": 0.180435535697605,
+        "step_median": 0.18043553569805226,
+        "step_std": 7.83016510157079e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1182,
+        "inf_count": 0,
+        "max": 1.0142202377319336,
+        "mean": 0.9959922232704518,
+        "median": 0.9988044798374176,
+        "min": 0.8212175369262695,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.9308307164907456,
+          "25": 0.9955938756465912,
+          "5": 0.9831326067447662,
+          "50": 0.9988044798374176,
+          "75": 1.001516431570053,
+          "95": 1.0051758229732513,
+          "99": 1.0100826382637025
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9939776062965393
+          },
+          {
+            "index": 295,
+            "value": 1.008691430091858
+          },
+          {
+            "index": 591,
+            "value": 0.9944559931755066
+          },
+          {
+            "index": 886,
+            "value": 1.0040255784988403
+          },
+          {
+            "index": 1181,
+            "value": 0.8212175369262695
+          }
+        ],
+        "size": 1182,
+        "std": 0.014731186543182673,
+        "sum": 1177.262807905674,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9911561608314514,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 295,
+            "median": 1.0074083805084229,
+            "start_index": 293,
+            "stop_index": 298
+          },
+          {
+            "center_index": 591,
+            "median": 0.9944559931755066,
+            "start_index": 589,
+            "stop_index": 594
+          },
+          {
+            "center_index": 886,
+            "median": 1.0021001100540161,
+            "start_index": 884,
+            "stop_index": 889
+          },
+          {
+            "center_index": 1181,
+            "median": 0.8404713869094849,
+            "start_index": 1179,
+            "stop_index": 1182
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.176994601656012,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10481.0465792562,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1182
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m53_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1182
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10690.07720381195,
+        "max": 10690.07720381195,
+        "min": 10481.0465792562,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10481.0465792562
+          },
+          {
+            "index": 295,
+            "value": 10533.259986744724
+          },
+          {
+            "index": 591,
+            "value": 10585.650388834903
+          },
+          {
+            "index": 886,
+            "value": 10637.863796323427
+          },
+          {
+            "index": 1181,
+            "value": 10690.07720381195
+          }
+        ],
+        "start": 10481.0465792562,
+        "step": 0.176994601656012,
+        "step_median": 0.1769946016556787,
+        "step_std": 7.031869522940888e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1167,
+        "inf_count": 0,
+        "max": 1.0119291543960571,
+        "mean": 0.9982856467123612,
+        "median": 0.9989907145500183,
+        "min": 0.9697721600532532,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.9763450694084167,
+          "25": 0.9963035583496094,
+          "5": 0.9902545571327209,
+          "50": 0.9989907145500183,
+          "75": 1.0012882351875305,
+          "95": 1.004668080806732,
+          "99": 1.0072865509986877
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9971266984939575
+          },
+          {
+            "index": 291,
+            "value": 1.0035879611968994
+          },
+          {
+            "index": 583,
+            "value": 0.9973527193069458
+          },
+          {
+            "index": 875,
+            "value": 1.004420280456543
+          },
+          {
+            "index": 1166,
+            "value": 0.9962143898010254
+          }
+        ],
+        "size": 1167,
+        "std": 0.005210198182341902,
+        "sum": 1164.9993497133255,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0007960796356201,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 291,
+            "median": 1.0035879611968994,
+            "start_index": 289,
+            "stop_index": 294
+          },
+          {
+            "center_index": 583,
+            "median": 0.9973527193069458,
+            "start_index": 581,
+            "stop_index": 586
+          },
+          {
+            "center_index": 875,
+            "median": 0.9996359944343567,
+            "start_index": 873,
+            "stop_index": 878
+          },
+          {
+            "center_index": 1166,
+            "median": 0.9966669678688049,
+            "start_index": 1164,
+            "stop_index": 1167
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.173783018768597,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10288.0510561775,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1167
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m54_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1167
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10490.682056061685,
+        "max": 10490.682056061685,
+        "min": 10288.0510561775,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10288.0510561775
+          },
+          {
+            "index": 291,
+            "value": 10338.621914639163
+          },
+          {
+            "index": 583,
+            "value": 10389.366556119592
+          },
+          {
+            "index": 875,
+            "value": 10440.111197600023
+          },
+          {
+            "index": 1166,
+            "value": 10490.682056061685
+          }
+        ],
+        "start": 10288.0510561775,
+        "step": 0.173783018768597,
+        "step_median": 0.17378301876851765,
+        "step_std": 3.7200959433375815e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1128,
+        "inf_count": 0,
+        "max": 1.0129162073135376,
+        "mean": 0.9978454616581295,
+        "median": 0.9985979199409485,
+        "min": 0.9720970988273621,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.980386169552803,
+          "25": 0.9956809431314468,
+          "5": 0.9889782279729843,
+          "50": 0.9985979199409485,
+          "75": 1.0009866952896118,
+          "95": 1.0043955266475677,
+          "99": 1.0073958349227905
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9832320213317871
+          },
+          {
+            "index": 282,
+            "value": 0.9888801574707031
+          },
+          {
+            "index": 564,
+            "value": 0.9991770386695862
+          },
+          {
+            "index": 846,
+            "value": 0.9931067228317261
+          },
+          {
+            "index": 1127,
+            "value": 0.9994518756866455
+          }
+        ],
+        "size": 1128,
+        "std": 0.0050288150229109594,
+        "sum": 1125.56968075037,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9886710047721863,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 282,
+            "median": 0.9924750328063965,
+            "start_index": 280,
+            "stop_index": 285
+          },
+          {
+            "center_index": 564,
+            "median": 1.0007648468017578,
+            "start_index": 562,
+            "stop_index": 567
+          },
+          {
+            "center_index": 846,
+            "median": 0.994510293006897,
+            "start_index": 844,
+            "stop_index": 849
+          },
+          {
+            "center_index": 1127,
+            "median": 0.99916011095047,
+            "start_index": 1125,
+            "stop_index": 1128
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.170485177289539,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10105.1504354648,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1128
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m55_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1128
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10297.28723027011,
+        "max": 10297.28723027011,
+        "min": 10105.1504354648,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10105.1504354648
+          },
+          {
+            "index": 282,
+            "value": 10153.22725546045
+          },
+          {
+            "index": 564,
+            "value": 10201.3040754561
+          },
+          {
+            "index": 846,
+            "value": 10249.38089545175
+          },
+          {
+            "index": 1127,
+            "value": 10297.28723027011
+          }
+        ],
+        "start": 10105.1504354648,
+        "step": 0.170485177289539,
+        "step_median": 0.17048517729017476,
+        "step_std": 8.673739032060674e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1126,
+        "inf_count": 0,
+        "max": 1.0347204208374023,
+        "mean": 0.9930212294970694,
+        "median": 0.9980452060699463,
+        "min": 0.8374980092048645,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.8838248252868652,
+          "25": 0.992444634437561,
+          "5": 0.9673216193914413,
+          "50": 0.9980452060699463,
+          "75": 1.0010234713554382,
+          "95": 1.0067024230957031,
+          "99": 1.0284690260887146
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9926982522010803
+          },
+          {
+            "index": 281,
+            "value": 1.0007067918777466
+          },
+          {
+            "index": 563,
+            "value": 0.9960941672325134
+          },
+          {
+            "index": 844,
+            "value": 0.9722777009010315
+          },
+          {
+            "index": 1125,
+            "value": 1.011788010597229
+          }
+        ],
+        "size": 1126,
+        "std": 0.020337007985907957,
+        "sum": 1118.1419044137,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9867801666259766,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 281,
+            "median": 1.00257408618927,
+            "start_index": 279,
+            "stop_index": 284
+          },
+          {
+            "center_index": 563,
+            "median": 0.9991827607154846,
+            "start_index": 561,
+            "stop_index": 566
+          },
+          {
+            "center_index": 844,
+            "median": 0.9676944613456726,
+            "start_index": 842,
+            "stop_index": 847
+          },
+          {
+            "center_index": 1125,
+            "median": 1.0054287910461426,
+            "start_index": 1123,
+            "stop_index": 1126
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.16733867748593,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9925.7918226126,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1126
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m56_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1126
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10114.04783478427,
+        "max": 10114.04783478427,
+        "min": 9925.7918226126,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9925.7918226126
+          },
+          {
+            "index": 281,
+            "value": 9972.813990986147
+          },
+          {
+            "index": 563,
+            "value": 10020.003498037178
+          },
+          {
+            "index": 844,
+            "value": 10067.025666410726
+          },
+          {
+            "index": 1125,
+            "value": 10114.04783478427
+          }
+        ],
+        "start": 9925.7918226126,
+        "step": 0.16733867748593,
+        "step_median": 0.16733867748553166,
+        "step_std": 7.518646006325111e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1101,
+        "inf_count": 0,
+        "max": 1.1063352823257446,
+        "mean": 0.9879836636061673,
+        "median": 0.9961000680923462,
+        "min": 0.6666916608810425,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.8082234859466553,
+          "25": 0.9897679090499878,
+          "5": 0.9376755356788635,
+          "50": 0.9961000680923462,
+          "75": 0.9996711015701294,
+          "95": 1.0037490129470825,
+          "99": 1.044335961341858
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9251348376274109
+          },
+          {
+            "index": 275,
+            "value": 0.9951049089431763
+          },
+          {
+            "index": 550,
+            "value": 0.9678438901901245
+          },
+          {
+            "index": 825,
+            "value": 0.9853495359420776
+          },
+          {
+            "index": 1100,
+            "value": 1.0024551153182983
+          }
+        ],
+        "size": 1101,
+        "std": 0.03467885923914553,
+        "sum": 1087.7700136303902,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9213686585426331,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 275,
+            "median": 0.9951049089431763,
+            "start_index": 273,
+            "stop_index": 278
+          },
+          {
+            "center_index": 550,
+            "median": 0.9833629727363586,
+            "start_index": 548,
+            "stop_index": 553
+          },
+          {
+            "center_index": 825,
+            "median": 0.9853495359420776,
+            "start_index": 823,
+            "stop_index": 828
+          },
+          {
+            "center_index": 1100,
+            "median": 0.9977619051933289,
+            "start_index": 1098,
+            "stop_index": 1101
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.164368996227023,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9753.61581750591,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1101
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m57_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1101
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9934.421713355636,
+        "max": 9934.421713355636,
+        "min": 9753.61581750591,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9753.61581750591
+          },
+          {
+            "index": 275,
+            "value": 9798.817291468342
+          },
+          {
+            "index": 550,
+            "value": 9844.018765430772
+          },
+          {
+            "index": 825,
+            "value": 9889.220239393204
+          },
+          {
+            "index": 1100,
+            "value": 9934.421713355636
+          }
+        ],
+        "start": 9753.61581750591,
+        "step": 0.164368996227023,
+        "step_median": 0.1643689962274948,
+        "step_std": 7.969640260488713e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1088,
+        "inf_count": 0,
+        "max": 1.1201198101043701,
+        "mean": 0.9152420988539234,
+        "median": 0.9875260889530182,
+        "min": 0.03256775438785553,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.04495355147868395,
+          "25": 0.9343658238649368,
+          "5": 0.5466056942939759,
+          "50": 0.9875260889530182,
+          "75": 0.9992440640926361,
+          "95": 1.0070078849792479,
+          "99": 1.024871928691864
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.03365560993552208
+          },
+          {
+            "index": 272,
+            "value": 0.9924880266189575
+          },
+          {
+            "index": 544,
+            "value": 0.9968492388725281
+          },
+          {
+            "index": 816,
+            "value": 1.0057131052017212
+          },
+          {
+            "index": 1087,
+            "value": 0.9462738037109375
+          }
+        ],
+        "size": 1088,
+        "std": 0.19048442776240285,
+        "sum": 995.7834035530686,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.034310173243284225,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 272,
+            "median": 0.9881313443183899,
+            "start_index": 270,
+            "stop_index": 275
+          },
+          {
+            "center_index": 544,
+            "median": 0.9989610910415649,
+            "start_index": 542,
+            "stop_index": 547
+          },
+          {
+            "center_index": 816,
+            "median": 1.0024633407592773,
+            "start_index": 814,
+            "stop_index": 819
+          },
+          {
+            "center_index": 1087,
+            "median": 0.9439103007316589,
+            "start_index": 1085,
+            "stop_index": 1088
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.161412870494629,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9586.48824215831,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1088
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m58_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1088
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9761.94403238597,
+        "max": 9761.94403238597,
+        "min": 9586.48824215831,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9586.48824215831
+          },
+          {
+            "index": 272,
+            "value": 9630.392542932848
+          },
+          {
+            "index": 544,
+            "value": 9674.296843707389
+          },
+          {
+            "index": 816,
+            "value": 9718.201144481927
+          },
+          {
+            "index": 1087,
+            "value": 9761.94403238597
+          }
+        ],
+        "start": 9586.48824215831,
+        "step": 0.161412870494629,
+        "step_median": 0.16141287049504172,
+        "step_std": 7.62234750839062e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1074,
+        "inf_count": 0,
+        "max": 12.294438362121582,
+        "mean": 0.7689792592966412,
+        "median": 0.9463387727737427,
+        "min": -64.7624282836914,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -0.6778178948163986,
+          "25": 0.7869940102100372,
+          "5": 0.2179357275366783,
+          "50": 0.9463387727737427,
+          "75": 0.9980251044034958,
+          "95": 1.017591482400894,
+          "99": 1.526234729290007
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.004763126373291
+          },
+          {
+            "index": 268,
+            "value": 0.935326337814331
+          },
+          {
+            "index": 537,
+            "value": 1.0171946287155151
+          },
+          {
+            "index": 805,
+            "value": 0.9894920587539673
+          },
+          {
+            "index": 1073,
+            "value": -0.1671058088541031
+          }
+        ],
+        "size": 1074,
+        "std": 2.0976636621972,
+        "sum": 825.8837244845927,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9991342425346375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 268,
+            "median": 0.9769182801246643,
+            "start_index": 266,
+            "stop_index": 271
+          },
+          {
+            "center_index": 537,
+            "median": 1.0111405849456787,
+            "start_index": 535,
+            "stop_index": 540
+          },
+          {
+            "center_index": 805,
+            "median": 0.9895317554473877,
+            "start_index": 803,
+            "stop_index": 808
+          },
+          {
+            "center_index": 1073,
+            "median": -0.1815403252840042,
+            "start_index": 1071,
+            "stop_index": 1074
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.158532791239092,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9424.45986117665,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1074
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m59_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1074
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9594.565546176196,
+        "max": 9594.565546176196,
+        "min": 9424.45986117665,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9424.45986117665
+          },
+          {
+            "index": 268,
+            "value": 9466.946649228727
+          },
+          {
+            "index": 537,
+            "value": 9509.591970072042
+          },
+          {
+            "index": 805,
+            "value": 9552.07875812412
+          },
+          {
+            "index": 1073,
+            "value": 9594.565546176196
+          }
+        ],
+        "start": 9424.45986117665,
+        "step": 0.158532791239092,
+        "step_median": 0.15853279123984976,
+        "step_std": 8.967499793499216e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1034,
+        "inf_count": 0,
+        "max": 1.8247613906860352,
+        "mean": 0.8789133501655244,
+        "median": 0.9461210072040558,
+        "min": 0.08232757449150085,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.1469889523088932,
+          "25": 0.8077687919139862,
+          "5": 0.3286480143666268,
+          "50": 0.9461210072040558,
+          "75": 0.9970250278711319,
+          "95": 1.2038306474685665,
+          "99": 1.6069766342639915
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0030794143676758
+          },
+          {
+            "index": 258,
+            "value": 0.9354674220085144
+          },
+          {
+            "index": 517,
+            "value": 0.8979607820510864
+          },
+          {
+            "index": 775,
+            "value": 0.882724940776825
+          },
+          {
+            "index": 1033,
+            "value": 1.0040123462677002
+          }
+        ],
+        "size": 1034,
+        "std": 0.25339470593172697,
+        "sum": 908.7964040711522,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0019612312316895,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 258,
+            "median": 0.9354674220085144,
+            "start_index": 256,
+            "stop_index": 261
+          },
+          {
+            "center_index": 517,
+            "median": 0.8979607820510864,
+            "start_index": 515,
+            "stop_index": 520
+          },
+          {
+            "center_index": 775,
+            "median": 0.882724940776825,
+            "start_index": 773,
+            "stop_index": 778
+          },
+          {
+            "center_index": 1033,
+            "median": 0.9968953728675842,
+            "start_index": 1031,
+            "stop_index": 1034
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.155831937195421,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9271.21912249884,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1034
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m60_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1034
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9432.19351362171,
+        "max": 9432.19351362171,
+        "min": 9271.21912249884,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9271.21912249884
+          },
+          {
+            "index": 258,
+            "value": 9311.423762295259
+          },
+          {
+            "index": 517,
+            "value": 9351.784234028873
+          },
+          {
+            "index": 775,
+            "value": 9391.988873825292
+          },
+          {
+            "index": 1033,
+            "value": 9432.19351362171
+          }
+        ],
+        "start": 9271.21912249884,
+        "step": 0.155831937195421,
+        "step_median": 0.1558319371961261,
+        "step_std": 8.86057076164152e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1039,
+        "inf_count": 0,
+        "max": 1.0564405918121338,
+        "mean": 0.9472191282140164,
+        "median": 0.9871150255203247,
+        "min": 0.5794547200202942,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.6412710607051849,
+          "25": 0.929225355386734,
+          "5": 0.7268238663673401,
+          "50": 0.9871150255203247,
+          "75": 0.9993212223052979,
+          "95": 1.018038558959961,
+          "99": 1.0504632210731506
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0530256032943726
+          },
+          {
+            "index": 259,
+            "value": 0.9928900599479675
+          },
+          {
+            "index": 519,
+            "value": 0.9834245443344116
+          },
+          {
+            "index": 779,
+            "value": 0.9107458591461182
+          },
+          {
+            "index": 1038,
+            "value": 0.6795950531959534
+          }
+        ],
+        "size": 1039,
+        "std": 0.08935536290154922,
+        "sum": 984.1606742143631,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0530256032943726,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 259,
+            "median": 0.9928900599479675,
+            "start_index": 257,
+            "stop_index": 262
+          },
+          {
+            "center_index": 519,
+            "median": 0.984874427318573,
+            "start_index": 517,
+            "stop_index": 522
+          },
+          {
+            "center_index": 779,
+            "median": 0.9340551495552063,
+            "start_index": 777,
+            "stop_index": 782
+          },
+          {
+            "center_index": 1038,
+            "median": 0.8396458625793457,
+            "start_index": 1036,
+            "stop_index": 1039
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "air",
+        "CDELT1": 0.153162563138058,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9119.70741076317,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1039
+      },
+      "path": "4_Ari_sum/AIR_norm/fsr1.05/4_Ari_sum_m61_fsr1.05_AIR_norm.fits",
+      "shape": [
+        1039
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9278.690151300474,
+        "max": 9278.690151300474,
+        "min": 9119.70741076317,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9119.70741076317
+          },
+          {
+            "index": 259,
+            "value": 9159.376514615928
+          },
+          {
+            "index": 519,
+            "value": 9199.198781031822
+          },
+          {
+            "index": 779,
+            "value": 9239.021047447717
+          },
+          {
+            "index": 1038,
+            "value": 9278.690151300474
+          }
+        ],
+        "start": 9119.70741076317,
+        "step": 0.153162563138058,
+        "step_median": 0.15316256313781196,
+        "step_std": 6.213481387947486e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1503,
+        "inf_count": 0,
+        "max": 13126.12109375,
+        "mean": 8943.278562153646,
+        "median": 10161.49609375,
+        "min": -1907.60205078125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -599.8630688476562,
+          "25": 6098.18408203125,
+          "5": 1945.5074707031251,
+          "50": 10161.49609375,
+          "75": 11946.4794921875,
+          "95": 12791.86181640625,
+          "99": 12974.4398046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 10758.06640625
+          },
+          {
+            "index": 375,
+            "value": 12483.2734375
+          },
+          {
+            "index": 751,
+            "value": 11561.4765625
+          },
+          {
+            "index": 1127,
+            "value": 7994.7900390625
+          },
+          {
+            "index": 1502,
+            "value": -1580.688720703125
+          }
+        ],
+        "size": 1503,
+        "std": 3582.1699778471643,
+        "sum": 13441747.678916931,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 12318.759765625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 375,
+            "median": 12459.615234375,
+            "start_index": 373,
+            "stop_index": 378
+          },
+          {
+            "center_index": 751,
+            "median": 11561.4765625,
+            "start_index": 749,
+            "stop_index": 754
+          },
+          {
+            "center_index": 1127,
+            "median": 7994.7900390625,
+            "start_index": 1125,
+            "stop_index": 1130
+          },
+          {
+            "center_index": 1502,
+            "median": -1125.7740478515625,
+            "start_index": 1500,
+            "stop_index": 1503
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.22250540945406,
+        "CRPIX1": 1.0,
+        "CRVAL1": 13183.537109375,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1503
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m42_fsr1.05_VAC.fits",
+      "shape": [
+        1503
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13517.740234374998,
+        "max": 13517.740234374998,
+        "min": 13183.537109375,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 13183.537109375
+          },
+          {
+            "index": 375,
+            "value": 13266.976637920272
+          },
+          {
+            "index": 751,
+            "value": 13350.638671874998
+          },
+          {
+            "index": 1127,
+            "value": 13434.300705829726
+          },
+          {
+            "index": 1502,
+            "value": 13517.740234374998
+          }
+        ],
+        "start": 13183.537109375,
+        "step": 0.22250540945406,
+        "step_median": 0.2225054094542429,
+        "step_std": 5.469862190711904e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1423,
+        "inf_count": 0,
+        "max": 11024.609375,
+        "mean": 10071.4623862164,
+        "median": 10509.5703125,
+        "min": 4368.78076171875,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 6105.855302734375,
+          "25": 10100.39599609375,
+          "5": 7427.32587890625,
+          "50": 10509.5703125,
+          "75": 10647.7890625,
+          "95": 10777.418359375,
+          "99": 10925.8698046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 10283.7197265625
+          },
+          {
+            "index": 355,
+            "value": 10394.421875
+          },
+          {
+            "index": 711,
+            "value": 10315.32421875
+          },
+          {
+            "index": 1067,
+            "value": 10602.203125
+          },
+          {
+            "index": 1422,
+            "value": 6775.037109375
+          }
+        ],
+        "size": 1423,
+        "std": 1071.2034285561363,
+        "sum": 14331690.975585938,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 10433.1796875,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 355,
+            "median": 10510.248046875,
+            "start_index": 353,
+            "stop_index": 358
+          },
+          {
+            "center_index": 711,
+            "median": 10315.32421875,
+            "start_index": 709,
+            "stop_index": 714
+          },
+          {
+            "center_index": 1067,
+            "median": 10602.203125,
+            "start_index": 1065,
+            "stop_index": 1070
+          },
+          {
+            "center_index": 1422,
+            "median": 6779.71826171875,
+            "start_index": 1420,
+            "stop_index": 1423
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.21752620648734,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12889.330078125,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1423
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m43_fsr1.05_VAC.fits",
+      "shape": [
+        1423
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13198.652343749998,
+        "max": 13198.652343749998,
+        "min": 12889.330078125,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12889.330078125
+          },
+          {
+            "index": 355,
+            "value": 12966.551881428006
+          },
+          {
+            "index": 711,
+            "value": 13043.991210937498
+          },
+          {
+            "index": 1067,
+            "value": 13121.430540446992
+          },
+          {
+            "index": 1422,
+            "value": 13198.652343749998
+          }
+        ],
+        "start": 12889.330078125,
+        "step": 0.21752620648734,
+        "step_median": 0.21752620648658194,
+        "step_std": 8.968817453041697e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1444,
+        "inf_count": 0,
+        "max": 10659.169921875,
+        "mean": 9618.207985494935,
+        "median": 10082.2958984375,
+        "min": 3448.692626953125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 5669.552060546875,
+          "25": 9310.712646484375,
+          "5": 7046.575390625,
+          "50": 10082.2958984375,
+          "75": 10286.30712890625,
+          "95": 10571.23134765625,
+          "99": 10626.231494140626
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 10060.9072265625
+          },
+          {
+            "index": 361,
+            "value": 10249.087890625
+          },
+          {
+            "index": 722,
+            "value": 10554.1796875
+          },
+          {
+            "index": 1083,
+            "value": 8340.5625
+          },
+          {
+            "index": 1443,
+            "value": 10130.0908203125
+          }
+        ],
+        "size": 1444,
+        "std": 1109.9978004259417,
+        "sum": 13888692.331054688,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 10130.0234375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 361,
+            "median": 10185.693359375,
+            "start_index": 359,
+            "stop_index": 364
+          },
+          {
+            "center_index": 722,
+            "median": 10564.279296875,
+            "start_index": 720,
+            "stop_index": 725
+          },
+          {
+            "center_index": 1083,
+            "median": 8330.0244140625,
+            "start_index": 1081,
+            "stop_index": 1086
+          },
+          {
+            "center_index": 1443,
+            "median": 10130.0908203125,
+            "start_index": 1441,
+            "stop_index": 1444
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.21276271764553,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12596.78515625,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1444
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m44_fsr1.05_VAC.fits",
+      "shape": [
+        1444
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12903.8017578125,
+        "max": 12903.8017578125,
+        "min": 12596.78515625,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12596.78515625
+          },
+          {
+            "index": 361,
+            "value": 12673.592497320036
+          },
+          {
+            "index": 722,
+            "value": 12750.399838390073
+          },
+          {
+            "index": 1083,
+            "value": 12827.207179460109
+          },
+          {
+            "index": 1443,
+            "value": 12903.8017578125
+          }
+        ],
+        "start": 12596.78515625,
+        "step": 0.21276271764553,
+        "step_median": 0.21276271764509147,
+        "step_std": 7.781449791299892e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1388,
+        "inf_count": 0,
+        "max": 11998.513671875,
+        "mean": 11487.43682034627,
+        "median": 11644.03759765625,
+        "min": 6467.1806640625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 9507.35220703125,
+          "25": 11372.27294921875,
+          "5": 10574.24267578125,
+          "50": 11644.03759765625,
+          "75": 11811.914794921875,
+          "95": 11899.131982421875,
+          "99": 11944.26443359375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 11406.28515625
+          },
+          {
+            "index": 347,
+            "value": 11863.22265625
+          },
+          {
+            "index": 694,
+            "value": 11506.1376953125
+          },
+          {
+            "index": 1041,
+            "value": 11405.71875
+          },
+          {
+            "index": 1387,
+            "value": 10340.9140625
+          }
+        ],
+        "size": 1388,
+        "std": 512.5756262326794,
+        "sum": 15944562.306640625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 11462.109375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 347,
+            "median": 11840.01171875,
+            "start_index": 345,
+            "stop_index": 350
+          },
+          {
+            "center_index": 694,
+            "median": 11506.1376953125,
+            "start_index": 692,
+            "stop_index": 697
+          },
+          {
+            "center_index": 1041,
+            "median": 11405.71875,
+            "start_index": 1039,
+            "stop_index": 1044
+          },
+          {
+            "center_index": 1387,
+            "median": 10599.81640625,
+            "start_index": 1385,
+            "stop_index": 1388
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.20810920038753,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12322.122070312,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1388
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m45_fsr1.05_VAC.fits",
+      "shape": [
+        1388
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12610.769531249503,
+        "max": 12610.769531249503,
+        "min": 12322.122070312,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12322.122070312
+          },
+          {
+            "index": 347,
+            "value": 12394.335962846473
+          },
+          {
+            "index": 694,
+            "value": 12466.549855380945
+          },
+          {
+            "index": 1041,
+            "value": 12538.763747915418
+          },
+          {
+            "index": 1387,
+            "value": 12610.769531249503
+          }
+        ],
+        "start": 12322.122070312,
+        "step": 0.20810920038753,
+        "step_median": 0.20810920038820768,
+        "step_std": 8.795460973135906e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1365,
+        "inf_count": 0,
+        "max": 13114.626953125,
+        "mean": 12504.327069024725,
+        "median": 12571.0576171875,
+        "min": 9581.8935546875,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 11007.403515625,
+          "25": 12290.787109375,
+          "5": 11836.847265625,
+          "50": 12571.0576171875,
+          "75": 12806.4140625,
+          "95": 12961.88125,
+          "99": 13027.519609375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 12285.9296875
+          },
+          {
+            "index": 341,
+            "value": 12617.828125
+          },
+          {
+            "index": 682,
+            "value": 12949.171875
+          },
+          {
+            "index": 1023,
+            "value": 12540.724609375
+          },
+          {
+            "index": 1364,
+            "value": 11971.892578125
+          }
+        ],
+        "size": 1365,
+        "std": 396.7139268582682,
+        "sum": 17068406.44921875,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 12336.1181640625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 341,
+            "median": 12681.3486328125,
+            "start_index": 339,
+            "stop_index": 344
+          },
+          {
+            "center_index": 682,
+            "median": 12949.171875,
+            "start_index": 680,
+            "stop_index": 685
+          },
+          {
+            "center_index": 1023,
+            "median": 12540.724609375,
+            "start_index": 1021,
+            "stop_index": 1026
+          },
+          {
+            "center_index": 1364,
+            "median": 11953.099609375,
+            "start_index": 1362,
+            "stop_index": 1365
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.20384596659641,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12057.375,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1365
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m46_fsr1.05_VAC.fits",
+      "shape": [
+        1365
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12335.420898437504,
+        "max": 12335.420898437504,
+        "min": 12057.375,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12057.375
+          },
+          {
+            "index": 341,
+            "value": 12126.886474609375
+          },
+          {
+            "index": 682,
+            "value": 12196.397949218752
+          },
+          {
+            "index": 1023,
+            "value": 12265.909423828127
+          },
+          {
+            "index": 1364,
+            "value": 12335.420898437504
+          }
+        ],
+        "start": 12057.375,
+        "step": 0.20384596659641,
+        "step_median": 0.2038459665964183,
+        "step_std": 1.2037638857350936e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1332,
+        "inf_count": 0,
+        "max": 14272.599609375,
+        "mean": 13459.26160071204,
+        "median": 13697.458984375,
+        "min": 6729.01953125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 9247.78900390625,
+          "25": 13241.376953125,
+          "5": 11979.187890625,
+          "50": 13697.458984375,
+          "75": 13998.710205078125,
+          "95": 14150.974658203126,
+          "99": 14200.12556640625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 13274.623046875
+          },
+          {
+            "index": 333,
+            "value": 13848.9658203125
+          },
+          {
+            "index": 666,
+            "value": 14096.82421875
+          },
+          {
+            "index": 999,
+            "value": 13729.2421875
+          },
+          {
+            "index": 1331,
+            "value": 12412.7421875
+          }
+        ],
+        "size": 1332,
+        "std": 880.6724495091458,
+        "sum": 17927736.452148438,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 13258.28125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 333,
+            "median": 13985.947265625,
+            "start_index": 331,
+            "stop_index": 336
+          },
+          {
+            "center_index": 666,
+            "median": 14096.82421875,
+            "start_index": 664,
+            "stop_index": 669
+          },
+          {
+            "center_index": 999,
+            "median": 13710.90234375,
+            "start_index": 997,
+            "stop_index": 1002
+          },
+          {
+            "center_index": 1331,
+            "median": 12503.755859375,
+            "start_index": 1329,
+            "stop_index": 1332
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.19943739434636,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11804.674804687,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1332
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m47_fsr1.05_VAC.fits",
+      "shape": [
+        1332
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12070.125976562005,
+        "max": 12070.125976562005,
+        "min": 11804.674804687,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11804.674804687
+          },
+          {
+            "index": 333,
+            "value": 11871.087457004338
+          },
+          {
+            "index": 666,
+            "value": 11937.500109321676
+          },
+          {
+            "index": 999,
+            "value": 12003.912761639014
+          },
+          {
+            "index": 1331,
+            "value": 12070.125976562005
+          }
+        ],
+        "start": 11804.674804687,
+        "step": 0.19943739434636,
+        "step_median": 0.1994373943471146,
+        "step_std": 8.961699585393993e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1317,
+        "inf_count": 0,
+        "max": 15401.580078125,
+        "mean": 14334.855859152549,
+        "median": 14672.7041015625,
+        "min": 3657.91845703125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 8868.207265625,
+          "25": 14119.5,
+          "5": 12062.81640625,
+          "50": 14672.7041015625,
+          "75": 15060.162109375,
+          "95": 15275.08828125,
+          "99": 15361.34484375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 14001.783203125
+          },
+          {
+            "index": 329,
+            "value": 14610.97265625
+          },
+          {
+            "index": 658,
+            "value": 14440.205078125
+          },
+          {
+            "index": 987,
+            "value": 14772.197265625
+          },
+          {
+            "index": 1316,
+            "value": 14078.0
+          }
+        ],
+        "size": 1317,
+        "std": 1255.4710385650808,
+        "sum": 18879005.166503906,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 14001.783203125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 329,
+            "median": 14610.97265625,
+            "start_index": 327,
+            "stop_index": 332
+          },
+          {
+            "center_index": 658,
+            "median": 14727.109375,
+            "start_index": 656,
+            "stop_index": 661
+          },
+          {
+            "center_index": 987,
+            "median": 14772.197265625,
+            "start_index": 985,
+            "stop_index": 990
+          },
+          {
+            "center_index": 1316,
+            "median": 13965.16015625,
+            "start_index": 1314,
+            "stop_index": 1317
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.19556999786284,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11559.567382812,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1317
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m48_fsr1.05_VAC.fits",
+      "shape": [
+        1317
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11816.937499999498,
+        "max": 11816.937499999498,
+        "min": 11559.567382812,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11559.567382812
+          },
+          {
+            "index": 329,
+            "value": 11623.909912108875
+          },
+          {
+            "index": 658,
+            "value": 11688.252441405748
+          },
+          {
+            "index": 987,
+            "value": 11752.594970702623
+          },
+          {
+            "index": 1316,
+            "value": 11816.937499999498
+          }
+        ],
+        "start": 11559.567382812,
+        "step": 0.19556999786284,
+        "step_median": 0.19556999786254892,
+        "step_std": 6.674160502803061e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1269,
+        "inf_count": 0,
+        "max": 16608.482421875,
+        "mean": 12990.272939028187,
+        "median": 14967.5078125,
+        "min": 90.49747467041016,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 733.1523779296874,
+          "25": 12031.302734375,
+          "5": 2810.1604492187503,
+          "50": 14967.5078125,
+          "75": 15781.48828125,
+          "95": 16373.0396484375,
+          "99": 16540.67015625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 14613.896484375
+          },
+          {
+            "index": 317,
+            "value": 16252.2236328125
+          },
+          {
+            "index": 634,
+            "value": 1687.38427734375
+          },
+          {
+            "index": 951,
+            "value": 15694.54296875
+          },
+          {
+            "index": 1268,
+            "value": 14950.052734375
+          }
+        ],
+        "size": 1269,
+        "std": 4245.486312263981,
+        "sum": 16484656.35962677,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 14983.29296875,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 317,
+            "median": 16252.2236328125,
+            "start_index": 315,
+            "stop_index": 320
+          },
+          {
+            "center_index": 634,
+            "median": 4709.4541015625,
+            "start_index": 632,
+            "stop_index": 637
+          },
+          {
+            "center_index": 951,
+            "median": 15694.54296875,
+            "start_index": 949,
+            "stop_index": 954
+          },
+          {
+            "center_index": 1268,
+            "median": 15180.150390625,
+            "start_index": 1266,
+            "stop_index": 1269
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.19163190679219,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11328.309570312,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1269
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m49_fsr1.05_VAC.fits",
+      "shape": [
+        1269
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11571.298828124496,
+        "max": 11571.298828124496,
+        "min": 11328.309570312,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11328.309570312
+          },
+          {
+            "index": 317,
+            "value": 11389.056884765125
+          },
+          {
+            "index": 634,
+            "value": 11449.804199218248
+          },
+          {
+            "index": 951,
+            "value": 11510.551513671373
+          },
+          {
+            "index": 1268,
+            "value": 11571.298828124496
+          }
+        ],
+        "start": 11328.309570312,
+        "step": 0.19163190679219,
+        "step_median": 0.19163190679137188,
+        "step_std": 9.048488832183283e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1245,
+        "inf_count": 0,
+        "max": 18108.8125,
+        "mean": 13832.199309150665,
+        "median": 15880.921875,
+        "min": 190.45938110351562,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 784.911044921875,
+          "25": 11971.5625,
+          "5": 3103.28125,
+          "50": 15880.921875,
+          "75": 17133.2421875,
+          "95": 17813.979296875,
+          "99": 18018.10578125
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 8592.25390625
+          },
+          {
+            "index": 311,
+            "value": 11721.400390625
+          },
+          {
+            "index": 622,
+            "value": 15671.6064453125
+          },
+          {
+            "index": 933,
+            "value": 16126.9423828125
+          },
+          {
+            "index": 1244,
+            "value": 15473.3359375
+          }
+        ],
+        "size": 1245,
+        "std": 4595.966993300827,
+        "sum": 17221088.139892578,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 9994.64453125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 311,
+            "median": 11721.400390625,
+            "start_index": 309,
+            "stop_index": 314
+          },
+          {
+            "center_index": 622,
+            "median": 15671.6064453125,
+            "start_index": 620,
+            "stop_index": 625
+          },
+          {
+            "center_index": 933,
+            "median": 16126.9423828125,
+            "start_index": 931,
+            "stop_index": 936
+          },
+          {
+            "center_index": 1244,
+            "median": 15514.541015625,
+            "start_index": 1242,
+            "stop_index": 1245
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.18782028737942,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11105.83203125,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1245
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m50_fsr1.05_VAC.fits",
+      "shape": [
+        1245
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11339.480468749998,
+        "max": 11339.480468749998,
+        "min": 11105.83203125,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11105.83203125
+          },
+          {
+            "index": 311,
+            "value": 11164.244140625
+          },
+          {
+            "index": 622,
+            "value": 11222.65625
+          },
+          {
+            "index": 933,
+            "value": 11281.068359374998
+          },
+          {
+            "index": 1244,
+            "value": 11339.480468749998
+          }
+        ],
+        "start": 11105.83203125,
+        "step": 0.18782028737942,
+        "step_median": 0.18782028737950895,
+        "step_std": 3.927960200941427e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1231,
+        "inf_count": 0,
+        "max": 20030.1640625,
+        "mean": 18026.826576462227,
+        "median": 18605.69921875,
+        "min": 9313.275390625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 11778.3869140625,
+          "25": 17373.0693359375,
+          "5": 14112.18115234375,
+          "50": 18605.69921875,
+          "75": 19322.9892578125,
+          "95": 19816.6318359375,
+          "99": 19915.515625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 18588.8359375
+          },
+          {
+            "index": 307,
+            "value": 14748.837890625
+          },
+          {
+            "index": 615,
+            "value": 19789.365234375
+          },
+          {
+            "index": 923,
+            "value": 19457.662109375
+          },
+          {
+            "index": 1230,
+            "value": 18551.53515625
+          }
+        ],
+        "size": 1231,
+        "std": 1831.2051686876675,
+        "sum": 22191023.515625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 18583.720703125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 307,
+            "median": 14748.837890625,
+            "start_index": 305,
+            "stop_index": 310
+          },
+          {
+            "center_index": 615,
+            "median": 19769.34375,
+            "start_index": 613,
+            "stop_index": 618
+          },
+          {
+            "center_index": 923,
+            "median": 19290.8359375,
+            "start_index": 921,
+            "stop_index": 926
+          },
+          {
+            "center_index": 1230,
+            "median": 18473.677734375,
+            "start_index": 1228,
+            "stop_index": 1231
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.18415507494919,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10890.102539063,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1231
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m51_fsr1.05_VAC.fits",
+      "shape": [
+        1231
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11116.613281250504,
+        "max": 11116.613281250504,
+        "min": 10890.102539063,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10890.102539063
+          },
+          {
+            "index": 307,
+            "value": 10946.6381470724
+          },
+          {
+            "index": 615,
+            "value": 11003.357910156752
+          },
+          {
+            "index": 923,
+            "value": 11060.077673241103
+          },
+          {
+            "index": 1230,
+            "value": 11116.613281250504
+          }
+        ],
+        "start": 10890.102539063,
+        "step": 0.18415507494919,
+        "step_median": 0.1841550749486487,
+        "step_std": 8.316153014363072e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1206,
+        "inf_count": 0,
+        "max": 22252.302734375,
+        "mean": 21414.086800697034,
+        "median": 21595.9248046875,
+        "min": 17702.5703125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 19312.41796875,
+          "25": 21068.1474609375,
+          "5": 19918.09228515625,
+          "50": 21595.9248046875,
+          "75": 21967.93896484375,
+          "95": 22131.2060546875,
+          "99": 22205.309765625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 20700.103515625
+          },
+          {
+            "index": 301,
+            "value": 21839.078125
+          },
+          {
+            "index": 603,
+            "value": 22039.5234375
+          },
+          {
+            "index": 904,
+            "value": 21111.478515625
+          },
+          {
+            "index": 1205,
+            "value": 19533.900390625
+          }
+        ],
+        "size": 1206,
+        "std": 709.0756819698775,
+        "sum": 25825388.681640625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 20700.103515625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 301,
+            "median": 21865.68359375,
+            "start_index": 299,
+            "stop_index": 304
+          },
+          {
+            "center_index": 603,
+            "median": 22053.822265625,
+            "start_index": 601,
+            "stop_index": 606
+          },
+          {
+            "center_index": 904,
+            "median": 21237.109375,
+            "start_index": 902,
+            "stop_index": 907
+          },
+          {
+            "center_index": 1205,
+            "median": 19507.3125,
+            "start_index": 1203,
+            "stop_index": 1206
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.18048495850622,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10683.017578125,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1206
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m52_fsr1.05_VAC.fits",
+      "shape": [
+        1206
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10900.501953124995,
+        "max": 10900.501953124995,
+        "min": 10683.017578125,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10683.017578125
+          },
+          {
+            "index": 301,
+            "value": 10737.343550635373
+          },
+          {
+            "index": 603,
+            "value": 10791.850008104251
+          },
+          {
+            "index": 904,
+            "value": 10846.175980614624
+          },
+          {
+            "index": 1205,
+            "value": 10900.501953124995
+          }
+        ],
+        "start": 10683.017578125,
+        "step": 0.18048495850622,
+        "step_median": 0.18048495850598556,
+        "step_std": 6.089808286633043e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1182,
+        "inf_count": 0,
+        "max": 24452.78515625,
+        "mean": 23702.33393645569,
+        "median": 23867.0234375,
+        "min": 20329.62890625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 21398.86541015625,
+          "25": 23490.03173828125,
+          "5": 22591.85009765625,
+          "50": 23867.0234375,
+          "75": 24105.14599609375,
+          "95": 24278.60380859375,
+          "99": 24370.27525390625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 23319.734375
+          },
+          {
+            "index": 295,
+            "value": 24264.453125
+          },
+          {
+            "index": 591,
+            "value": 23983.31640625
+          },
+          {
+            "index": 886,
+            "value": 23702.7734375
+          },
+          {
+            "index": 1181,
+            "value": 20329.62890625
+          }
+        ],
+        "size": 1182,
+        "std": 577.4238789242054,
+        "sum": 28016158.712890625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 23260.166015625,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 295,
+            "median": 24233.4375,
+            "start_index": 293,
+            "stop_index": 298
+          },
+          {
+            "center_index": 591,
+            "median": 23983.31640625,
+            "start_index": 589,
+            "stop_index": 594
+          },
+          {
+            "center_index": 886,
+            "median": 23661.177734375,
+            "start_index": 884,
+            "stop_index": 889
+          },
+          {
+            "center_index": 1181,
+            "median": 20729.2578125,
+            "start_index": 1179,
+            "stop_index": 1182
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.1770430911304,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10483.91796875,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1182
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m53_fsr1.05_VAC.fits",
+      "shape": [
+        1182
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10693.005859375002,
+        "max": 10693.005859375002,
+        "min": 10483.91796875,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10483.91796875
+          },
+          {
+            "index": 295,
+            "value": 10536.145680633468
+          },
+          {
+            "index": 591,
+            "value": 10588.550435608066
+          },
+          {
+            "index": 886,
+            "value": 10640.778147491534
+          },
+          {
+            "index": 1181,
+            "value": 10693.005859375002
+          }
+        ],
+        "start": 10483.91796875,
+        "step": 0.1770430911304,
+        "step_median": 0.1770430911310541,
+        "step_std": 8.730429994440193e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1167,
+        "inf_count": 0,
+        "max": 27044.537109375,
+        "mean": 26395.007902875965,
+        "median": 26528.625,
+        "min": 24679.625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 24875.382890625,
+          "25": 26154.90625,
+          "5": 25562.3029296875,
+          "50": 26528.625,
+          "75": 26718.3701171875,
+          "95": 26880.340625,
+          "99": 26959.3071875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 25809.77734375
+          },
+          {
+            "index": 291,
+            "value": 26719.8125
+          },
+          {
+            "index": 583,
+            "value": 26696.458984375
+          },
+          {
+            "index": 875,
+            "value": 26486.3984375
+          },
+          {
+            "index": 1166,
+            "value": 24679.625
+          }
+        ],
+        "size": 1167,
+        "std": 444.99659819075794,
+        "sum": 30802974.22265625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 25916.923828125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 291,
+            "median": 26719.8125,
+            "start_index": 289,
+            "stop_index": 294
+          },
+          {
+            "center_index": 583,
+            "median": 26696.458984375,
+            "start_index": 581,
+            "stop_index": 586
+          },
+          {
+            "center_index": 875,
+            "median": 26364.1796875,
+            "start_index": 873,
+            "stop_index": 878
+          },
+          {
+            "center_index": 1166,
+            "median": 24735.626953125,
+            "start_index": 1164,
+            "stop_index": 1167
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.17383063759648,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10290.870117188,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1167
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m54_fsr1.05_VAC.fits",
+      "shape": [
+        1167
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10493.556640625497,
+        "max": 10493.556640625497,
+        "min": 10290.870117188,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10290.870117188
+          },
+          {
+            "index": 291,
+            "value": 10341.454832728576
+          },
+          {
+            "index": 583,
+            "value": 10392.213378906748
+          },
+          {
+            "index": 875,
+            "value": 10442.97192508492
+          },
+          {
+            "index": 1166,
+            "value": 10493.556640625497
+          }
+        ],
+        "start": 10290.870117188,
+        "step": 0.17383063759648,
+        "step_median": 0.17383063759734796,
+        "step_std": 9.085188280640363e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1128,
+        "inf_count": 0,
+        "max": 29916.0390625,
+        "mean": 29041.737058815383,
+        "median": 29115.98828125,
+        "min": 27448.02734375,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 27587.8163671875,
+          "25": 28686.494140625,
+          "5": 28066.721484375,
+          "50": 29115.98828125,
+          "75": 29494.1943359375,
+          "95": 29698.396875,
+          "99": 29790.708359375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 27590.48828125
+          },
+          {
+            "index": 282,
+            "value": 29016.3984375
+          },
+          {
+            "index": 564,
+            "value": 29543.4453125
+          },
+          {
+            "index": 846,
+            "value": 28814.6171875
+          },
+          {
+            "index": 1127,
+            "value": 28292.33984375
+          }
+        ],
+        "size": 1128,
+        "std": 517.9524764131254,
+        "sum": 32759079.40234375,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 27736.3828125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 282,
+            "median": 29118.001953125,
+            "start_index": 280,
+            "stop_index": 285
+          },
+          {
+            "center_index": 564,
+            "median": 29591.47265625,
+            "start_index": 562,
+            "stop_index": 567
+          },
+          {
+            "center_index": 846,
+            "median": 28860.044921875,
+            "start_index": 844,
+            "stop_index": 849
+          },
+          {
+            "center_index": 1127,
+            "median": 28292.33984375,
+            "start_index": 1125,
+            "stop_index": 1128
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.17053190161934,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10107.919921875,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1128
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m55_fsr1.05_VAC.fits",
+      "shape": [
+        1128
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10300.109374999996,
+        "max": 10300.109374999996,
+        "min": 10107.919921875,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10107.919921875
+          },
+          {
+            "index": 282,
+            "value": 10156.009918131655
+          },
+          {
+            "index": 564,
+            "value": 10204.099914388307
+          },
+          {
+            "index": 846,
+            "value": 10252.189910644962
+          },
+          {
+            "index": 1127,
+            "value": 10300.109374999996
+          }
+        ],
+        "start": 10107.919921875,
+        "step": 0.17053190161934,
+        "step_median": 0.17053190162005194,
+        "step_std": 8.877437137828389e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1126,
+        "inf_count": 0,
+        "max": 32224.7109375,
+        "mean": 29593.795319091365,
+        "median": 30889.08984375,
+        "min": 18095.126953125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 19143.26025390625,
+          "25": 28570.90869140625,
+          "5": 22558.8603515625,
+          "50": 30889.08984375,
+          "75": 31791.61083984375,
+          "95": 31999.0927734375,
+          "99": 32109.08935546875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 31537.8671875
+          },
+          {
+            "index": 281,
+            "value": 31960.1171875
+          },
+          {
+            "index": 563,
+            "value": 29757.953125
+          },
+          {
+            "index": 844,
+            "value": 27550.65234375
+          },
+          {
+            "index": 1125,
+            "value": 29187.966796875
+          }
+        ],
+        "size": 1126,
+        "std": 3061.5137205575506,
+        "sum": 33322613.529296875,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 31329.96484375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 281,
+            "median": 32017.384765625,
+            "start_index": 279,
+            "stop_index": 284
+          },
+          {
+            "center_index": 563,
+            "median": 29870.7109375,
+            "start_index": 561,
+            "stop_index": 566
+          },
+          {
+            "center_index": 844,
+            "median": 27450.37890625,
+            "start_index": 842,
+            "stop_index": 847
+          },
+          {
+            "center_index": 1125,
+            "median": 29187.80078125,
+            "start_index": 1123,
+            "stop_index": 1126
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.16738454861111,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9928.51269531251,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1126
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m56_fsr1.05_VAC.fits",
+      "shape": [
+        1126
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10116.820312500007,
+        "max": 10116.820312500007,
+        "min": 9928.51269531251,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9928.51269531251
+          },
+          {
+            "index": 281,
+            "value": 9975.54775347223
+          },
+          {
+            "index": 563,
+            "value": 10022.750196180565
+          },
+          {
+            "index": 844,
+            "value": 10069.785254340286
+          },
+          {
+            "index": 1125,
+            "value": 10116.820312500007
+          }
+        ],
+        "start": 9928.51269531251,
+        "step": 0.16738454861111,
+        "step_median": 0.16738454861115315,
+        "step_std": 2.7839453063596145e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1101,
+        "inf_count": 0,
+        "max": 35927.9296875,
+        "mean": 34976.09550089407,
+        "median": 35297.796875,
+        "min": 22647.890625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 28184.587890625,
+          "25": 35013.62890625,
+          "5": 33030.01953125,
+          "50": 35297.796875,
+          "75": 35512.5,
+          "95": 35747.89453125,
+          "99": 35826.984375
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 28197.55078125
+          },
+          {
+            "index": 275,
+            "value": 35332.0546875
+          },
+          {
+            "index": 550,
+            "value": 34445.3984375
+          },
+          {
+            "index": 825,
+            "value": 34867.66015625
+          },
+          {
+            "index": 1100,
+            "value": 35338.6953125
+          }
+        ],
+        "size": 1101,
+        "std": 1297.9504027652642,
+        "sum": 38508681.146484375,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 28197.55078125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 275,
+            "median": 35332.0546875,
+            "start_index": 273,
+            "stop_index": 278
+          },
+          {
+            "center_index": 550,
+            "median": 35001.234375,
+            "start_index": 548,
+            "stop_index": 553
+          },
+          {
+            "center_index": 825,
+            "median": 34867.66015625,
+            "start_index": 823,
+            "stop_index": 828
+          },
+          {
+            "center_index": 1100,
+            "median": 35196.37109375,
+            "start_index": 1098,
+            "stop_index": 1101
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.1644140625,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9756.29003906251,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1101
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m57_fsr1.05_VAC.fits",
+      "shape": [
+        1101
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9937.14550781251,
+        "max": 9937.14550781251,
+        "min": 9756.29003906251,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9756.29003906251
+          },
+          {
+            "index": 275,
+            "value": 9801.50390625001
+          },
+          {
+            "index": 550,
+            "value": 9846.71777343751
+          },
+          {
+            "index": 825,
+            "value": 9891.93164062501
+          },
+          {
+            "index": 1100,
+            "value": 9937.14550781251
+          }
+        ],
+        "start": 9756.29003906251,
+        "step": 0.1644140625,
+        "step_median": 0.16441406249941792,
+        "step_std": 8.485151768493295e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1088,
+        "inf_count": 0,
+        "max": 39516.9140625,
+        "mean": 36596.174416934744,
+        "median": 38144.138671875,
+        "min": 18670.80078125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 22334.92921875,
+          "25": 35992.888671875,
+          "5": 28613.2556640625,
+          "50": 38144.138671875,
+          "75": 38833.0517578125,
+          "95": 39172.637109375,
+          "99": 39315.7398046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 35746.7890625
+          },
+          {
+            "index": 272,
+            "value": 37825.140625
+          },
+          {
+            "index": 544,
+            "value": 38970.71875
+          },
+          {
+            "index": 816,
+            "value": 39179.17578125
+          },
+          {
+            "index": 1087,
+            "value": 37190.1875
+          }
+        ],
+        "size": 1088,
+        "std": 3631.805811274457,
+        "sum": 39816637.765625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 35533.67578125,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 272,
+            "median": 37689.671875,
+            "start_index": 270,
+            "stop_index": 275
+          },
+          {
+            "center_index": 544,
+            "median": 39054.31640625,
+            "start_index": 542,
+            "stop_index": 547
+          },
+          {
+            "center_index": 816,
+            "median": 39048.0625,
+            "start_index": 814,
+            "stop_index": 819
+          },
+          {
+            "center_index": 1087,
+            "median": 37018.2734375,
+            "start_index": 1085,
+            "stop_index": 1088
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.16145713546458,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9589.11718750001,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1088
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m58_fsr1.05_VAC.fits",
+      "shape": [
+        1088
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9764.621093750007,
+        "max": 9764.621093750007,
+        "min": 9589.11718750001,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9589.11718750001
+          },
+          {
+            "index": 272,
+            "value": 9633.033528346376
+          },
+          {
+            "index": 544,
+            "value": 9676.94986919274
+          },
+          {
+            "index": 816,
+            "value": 9720.866210039107
+          },
+          {
+            "index": 1087,
+            "value": 9764.621093750007
+          }
+        ],
+        "start": 9589.11718750001,
+        "step": 0.16145713546458,
+        "step_median": 0.1614571354639338,
+        "step_std": 8.704689541852579e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1074,
+        "inf_count": 0,
+        "max": 42287.0859375,
+        "mean": 33203.66710061867,
+        "median": 35431.201171875,
+        "min": 2495.932861328125,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 5959.55939453125,
+          "25": 29209.85791015625,
+          "5": 14964.40615234375,
+          "50": 35431.201171875,
+          "75": 39769.9697265625,
+          "95": 41704.301953125,
+          "99": 42093.973046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 40733.015625
+          },
+          {
+            "index": 268,
+            "value": 38575.7109375
+          },
+          {
+            "index": 537,
+            "value": 40450.16015625
+          },
+          {
+            "index": 805,
+            "value": 30049.82421875
+          },
+          {
+            "index": 1073,
+            "value": 35028.2734375
+          }
+        ],
+        "size": 1074,
+        "std": 8391.700008296355,
+        "sum": 35660738.46606445,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 40513.71875,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 268,
+            "median": 40284.046875,
+            "start_index": 266,
+            "stop_index": 271
+          },
+          {
+            "center_index": 537,
+            "median": 40194.1015625,
+            "start_index": 535,
+            "stop_index": 540
+          },
+          {
+            "center_index": 805,
+            "median": 30049.82421875,
+            "start_index": 803,
+            "stop_index": 808
+          },
+          {
+            "center_index": 1073,
+            "median": 35028.2734375,
+            "start_index": 1071,
+            "stop_index": 1074
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.15857627562908,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9427.04492187501,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1074
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m59_fsr1.05_VAC.fits",
+      "shape": [
+        1074
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9597.197265625013,
+        "max": 9597.197265625013,
+        "min": 9427.04492187501,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9427.04492187501
+          },
+          {
+            "index": 268,
+            "value": 9469.543363743602
+          },
+          {
+            "index": 537,
+            "value": 9512.200381887826
+          },
+          {
+            "index": 805,
+            "value": 9554.698823756418
+          },
+          {
+            "index": 1073,
+            "value": 9597.197265625013
+          }
+        ],
+        "start": 9427.04492187501,
+        "step": 0.15857627562908,
+        "step_median": 0.1585762756294571,
+        "step_std": 7.368374898866198e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1034,
+        "inf_count": 0,
+        "max": 47171.4765625,
+        "mean": 39002.58976536056,
+        "median": 43546.29296875,
+        "min": 3461.53271484375,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 6841.514296875,
+          "25": 37017.7001953125,
+          "5": 14768.715478515625,
+          "50": 43546.29296875,
+          "75": 45282.404296875,
+          "95": 46424.819140625,
+          "99": 46842.131015625
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 44994.328125
+          },
+          {
+            "index": 258,
+            "value": 43285.875
+          },
+          {
+            "index": 517,
+            "value": 45042.234375
+          },
+          {
+            "index": 775,
+            "value": 40577.40625
+          },
+          {
+            "index": 1033,
+            "value": 45918.875
+          }
+        ],
+        "size": 1034,
+        "std": 9910.2224187167,
+        "sum": 40328677.81738281,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 44946.3359375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 258,
+            "median": 43285.875,
+            "start_index": 256,
+            "stop_index": 261
+          },
+          {
+            "center_index": 517,
+            "median": 45042.234375,
+            "start_index": 515,
+            "stop_index": 520
+          },
+          {
+            "center_index": 775,
+            "median": 40577.40625,
+            "start_index": 773,
+            "stop_index": 778
+          },
+          {
+            "center_index": 1033,
+            "median": 45434.25,
+            "start_index": 1031,
+            "stop_index": 1034
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.15587468992014,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9273.76269531251,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1034
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m60_fsr1.05_VAC.fits",
+      "shape": [
+        1034
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9434.781250000015,
+        "max": 9434.781250000015,
+        "min": 9273.76269531251,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9273.76269531251
+          },
+          {
+            "index": 258,
+            "value": 9313.978365311905
+          },
+          {
+            "index": 517,
+            "value": 9354.349910001221
+          },
+          {
+            "index": 775,
+            "value": 9394.565580000617
+          },
+          {
+            "index": 1033,
+            "value": 9434.781250000015
+          }
+        ],
+        "start": 9273.76269531251,
+        "step": 0.15587468992014,
+        "step_median": 0.1558746899208927,
+        "step_std": 8.957361405449461e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1039,
+        "inf_count": 0,
+        "max": 51792.96875,
+        "mean": 45617.37819192132,
+        "median": 47466.859375,
+        "min": 29235.0390625,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 30467.007890625,
+          "25": 42349.51953125,
+          "5": 33846.86484375,
+          "50": 47466.859375,
+          "75": 50057.6953125,
+          "95": 51246.086328125,
+          "99": 51538.40046875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 50553.7265625
+          },
+          {
+            "index": 259,
+            "value": 50813.015625
+          },
+          {
+            "index": 519,
+            "value": 47252.0546875
+          },
+          {
+            "index": 779,
+            "value": 37551.140625
+          },
+          {
+            "index": 1038,
+            "value": 34511.78125
+          }
+        ],
+        "size": 1039,
+        "std": 5536.930031779965,
+        "sum": 47396455.94140625,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 50793.7109375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 259,
+            "median": 50813.015625,
+            "start_index": 257,
+            "stop_index": 262
+          },
+          {
+            "center_index": 519,
+            "median": 47387.6484375,
+            "start_index": 517,
+            "stop_index": 522
+          },
+          {
+            "center_index": 779,
+            "median": 38491.9375,
+            "start_index": 777,
+            "stop_index": 782
+          },
+          {
+            "center_index": 1038,
+            "median": 42637.484375,
+            "start_index": 1036,
+            "stop_index": 1039
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.15320459266618,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9122.20996093751,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1039
+      },
+      "path": "4_Ari_sum/VAC_flux/fsr1.05/4_Ari_sum_m61_fsr1.05_VAC.fits",
+      "shape": [
+        1039
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9281.236328125004,
+        "max": 9281.236328125004,
+        "min": 9122.20996093751,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9122.20996093751
+          },
+          {
+            "index": 259,
+            "value": 9161.88995043805
+          },
+          {
+            "index": 519,
+            "value": 9201.723144531257
+          },
+          {
+            "index": 779,
+            "value": 9241.556338624463
+          },
+          {
+            "index": 1038,
+            "value": 9281.236328125004
+          }
+        ],
+        "start": 9122.20996093751,
+        "step": 0.15320459266618,
+        "step_median": 0.15320459266695252,
+        "step_std": 8.991647562580567e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 28692,
+        "inf_count": 0,
+        "max": 6.017922401428223,
+        "mean": 0.9398373524633242,
+        "median": 0.9944495856761932,
+        "min": -22.516572952270508,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.17651109516620636,
+          "25": 0.9639155566692352,
+          "5": 0.6490651190280915,
+          "50": 0.9944495856761932,
+          "75": 0.999856635928154,
+          "95": 1.0063828468322753,
+          "99": 1.026479014158249
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0530256032943726
+          },
+          {
+            "index": 7173,
+            "value": 1.0021692514419556
+          },
+          {
+            "index": 14346,
+            "value": 0.9442554712295532
+          },
+          {
+            "index": 21519,
+            "value": 0.9983080625534058
+          },
+          {
+            "index": 28691,
+            "value": -0.26573818922042847
+          }
+        ],
+        "size": 28692,
+        "std": 0.25983499178317554,
+        "sum": 26965.8133168777,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0530080795288086,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 7173,
+            "median": 1.0021692514419556,
+            "start_index": 7171,
+            "stop_index": 7176
+          },
+          {
+            "center_index": 14346,
+            "median": 0.9442554712295532,
+            "start_index": 14344,
+            "stop_index": 14349
+          },
+          {
+            "center_index": 21519,
+            "median": 0.9983080625534058,
+            "start_index": 21517,
+            "stop_index": 21522
+          },
+          {
+            "center_index": 28691,
+            "median": -0.18072478473186493,
+            "start_index": 28689,
+            "stop_index": 28692
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.15320240749495,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9122.20996093751,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 28692
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_fsr1.05_VAC_norm_comb.fits",
+      "shape": [
+        28692
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13517.74023437512,
+        "max": 13517.74023437512,
+        "min": 9122.20996093751,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9122.20996093751
+          },
+          {
+            "index": 7173,
+            "value": 10221.130829898786
+          },
+          {
+            "index": 14346,
+            "value": 11320.051698860061
+          },
+          {
+            "index": 21519,
+            "value": 12418.972567821338
+          },
+          {
+            "index": 28691,
+            "value": 13517.74023437512
+          }
+        ],
+        "start": 9122.20996093751,
+        "step": 0.15320240749495,
+        "step_median": 0.15320240749497316,
+        "step_std": 2.0385602027420993e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1503,
+        "inf_count": 0,
+        "max": 1.3739925622940063,
+        "mean": 0.8628918484035515,
+        "median": 0.9741634726524353,
+        "min": -0.4304264783859253,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -0.1364423942565918,
+          "25": 0.8176759779453278,
+          "5": 0.3289551019668579,
+          "50": 0.9741634726524353,
+          "75": 1.004616379737854,
+          "95": 1.023898434638977,
+          "99": 1.100060124397278
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.8464686870574951
+          },
+          {
+            "index": 375,
+            "value": 1.0096803903579712
+          },
+          {
+            "index": 751,
+            "value": 1.0092204809188843
+          },
+          {
+            "index": 1127,
+            "value": 1.0286388397216797
+          },
+          {
+            "index": 1502,
+            "value": -0.2729581594467163
+          }
+        ],
+        "size": 1503,
+        "std": 0.24369373255119317,
+        "sum": 1296.926448150538,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.96893709897995,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 375,
+            "median": 1.0073227882385254,
+            "start_index": 373,
+            "stop_index": 378
+          },
+          {
+            "center_index": 751,
+            "median": 1.0092204809188843,
+            "start_index": 749,
+            "stop_index": 754
+          },
+          {
+            "center_index": 1127,
+            "median": 1.0277574062347412,
+            "start_index": 1125,
+            "stop_index": 1130
+          },
+          {
+            "center_index": 1502,
+            "median": -0.19829429686069489,
+            "start_index": 1500,
+            "stop_index": 1503
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.22250540945406,
+        "CRPIX1": 1.0,
+        "CRVAL1": 13183.537109375,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1503
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m42_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1503
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13517.740234374998,
+        "max": 13517.740234374998,
+        "min": 13183.537109375,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 13183.537109375
+          },
+          {
+            "index": 375,
+            "value": 13266.976637920272
+          },
+          {
+            "index": 751,
+            "value": 13350.638671874998
+          },
+          {
+            "index": 1127,
+            "value": 13434.300705829726
+          },
+          {
+            "index": 1502,
+            "value": 13517.740234374998
+          }
+        ],
+        "start": 13183.537109375,
+        "step": 0.22250540945406,
+        "step_median": 0.2225054094542429,
+        "step_std": 5.469862190711904e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1423,
+        "inf_count": 0,
+        "max": 1.0174169540405273,
+        "mean": 0.9760635392982526,
+        "median": 0.9943099617958069,
+        "min": 0.4227278530597687,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.6808730721473694,
+          "25": 0.9798784255981445,
+          "5": 0.8816131472587585,
+          "50": 0.9943099617958069,
+          "75": 0.9994941055774689,
+          "95": 1.004460871219635,
+          "99": 1.0097497034072875
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9861146211624146
+          },
+          {
+            "index": 355,
+            "value": 0.9786655306816101
+          },
+          {
+            "index": 711,
+            "value": 0.9645792841911316
+          },
+          {
+            "index": 1067,
+            "value": 0.9926929473876953
+          },
+          {
+            "index": 1422,
+            "value": 0.9727053046226501
+          }
+        ],
+        "size": 1423,
+        "std": 0.05723261201539516,
+        "sum": 1388.9384164214134,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0002963542938232,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 355,
+            "median": 0.9894715547561646,
+            "start_index": 353,
+            "stop_index": 358
+          },
+          {
+            "center_index": 711,
+            "median": 0.9645792841911316,
+            "start_index": 709,
+            "stop_index": 714
+          },
+          {
+            "center_index": 1067,
+            "median": 0.9926929473876953,
+            "start_index": 1065,
+            "stop_index": 1070
+          },
+          {
+            "center_index": 1422,
+            "median": 0.9737085103988647,
+            "start_index": 1420,
+            "stop_index": 1423
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.21752620648734,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12889.330078125,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1423
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m43_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1423
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 13198.652343749998,
+        "max": 13198.652343749998,
+        "min": 12889.330078125,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12889.330078125
+          },
+          {
+            "index": 355,
+            "value": 12966.551881428006
+          },
+          {
+            "index": 711,
+            "value": 13043.991210937498
+          },
+          {
+            "index": 1067,
+            "value": 13121.430540446992
+          },
+          {
+            "index": 1422,
+            "value": 13198.652343749998
+          }
+        ],
+        "start": 12889.330078125,
+        "step": 0.21752620648734,
+        "step_median": 0.21752620648658194,
+        "step_std": 8.968817453041697e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1444,
+        "inf_count": 0,
+        "max": 1.010928988456726,
+        "mean": 0.9520870295876942,
+        "median": 0.994228184223175,
+        "min": 0.33631187677383423,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.5555250018835067,
+          "25": 0.9626784771680832,
+          "5": 0.7215249627828598,
+          "50": 0.994228184223175,
+          "75": 0.9992671310901642,
+          "95": 1.0038607716560364,
+          "99": 1.0062836301326752
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9948727488517761
+          },
+          {
+            "index": 361,
+            "value": 1.0040696859359741
+          },
+          {
+            "index": 722,
+            "value": 0.9965012669563293
+          },
+          {
+            "index": 1083,
+            "value": 0.9610736966133118
+          },
+          {
+            "index": 1443,
+            "value": 0.9852023124694824
+          }
+        ],
+        "size": 1444,
+        "std": 0.09716214604022387,
+        "sum": 1374.8136707246304,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.001591682434082,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 361,
+            "median": 0.9979012608528137,
+            "start_index": 359,
+            "stop_index": 364
+          },
+          {
+            "center_index": 722,
+            "median": 0.9974427223205566,
+            "start_index": 720,
+            "stop_index": 725
+          },
+          {
+            "center_index": 1083,
+            "median": 0.9589628577232361,
+            "start_index": 1081,
+            "stop_index": 1086
+          },
+          {
+            "center_index": 1443,
+            "median": 0.9852023124694824,
+            "start_index": 1441,
+            "stop_index": 1444
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.21276271764553,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12596.78515625,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1444
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m44_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1444
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12903.8017578125,
+        "max": 12903.8017578125,
+        "min": 12596.78515625,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12596.78515625
+          },
+          {
+            "index": 361,
+            "value": 12673.592497320036
+          },
+          {
+            "index": 722,
+            "value": 12750.399838390073
+          },
+          {
+            "index": 1083,
+            "value": 12827.207179460109
+          },
+          {
+            "index": 1443,
+            "value": 12903.8017578125
+          }
+        ],
+        "start": 12596.78515625,
+        "step": 0.21276271764553,
+        "step_median": 0.21276271764509147,
+        "step_std": 7.781449791299892e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1388,
+        "inf_count": 0,
+        "max": 1.0202733278274536,
+        "mean": 0.9936652184821,
+        "median": 0.9981638789176941,
+        "min": 0.6135095953941345,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.871470999121666,
+          "25": 0.9945069551467896,
+          "5": 0.9771568775177002,
+          "50": 0.9981638789176941,
+          "75": 1.0011822581291199,
+          "95": 1.0059946715831756,
+          "99": 1.0092887210845947
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.002463459968567
+          },
+          {
+            "index": 347,
+            "value": 1.0038187503814697
+          },
+          {
+            "index": 694,
+            "value": 0.9716183543205261
+          },
+          {
+            "index": 1041,
+            "value": 0.9942705035209656
+          },
+          {
+            "index": 1387,
+            "value": 0.9786087870597839
+          }
+        ],
+        "size": 1388,
+        "std": 0.02654602674328954,
+        "sum": 1379.2073232531548,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0071009397506714,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 347,
+            "median": 1.0017776489257812,
+            "start_index": 345,
+            "stop_index": 350
+          },
+          {
+            "center_index": 694,
+            "median": 0.9716183543205261,
+            "start_index": 692,
+            "stop_index": 697
+          },
+          {
+            "center_index": 1041,
+            "median": 0.9942705035209656,
+            "start_index": 1039,
+            "stop_index": 1044
+          },
+          {
+            "center_index": 1387,
+            "median": 1.0037237405776978,
+            "start_index": 1385,
+            "stop_index": 1388
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.20810920038753,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12322.122070312,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1388
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m45_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1388
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12610.769531249503,
+        "max": 12610.769531249503,
+        "min": 12322.122070312,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12322.122070312
+          },
+          {
+            "index": 347,
+            "value": 12394.335962846473
+          },
+          {
+            "index": 694,
+            "value": 12466.549855380945
+          },
+          {
+            "index": 1041,
+            "value": 12538.763747915418
+          },
+          {
+            "index": 1387,
+            "value": 12610.769531249503
+          }
+        ],
+        "start": 12322.122070312,
+        "step": 0.20810920038753,
+        "step_median": 0.20810920038820768,
+        "step_std": 8.795460973135906e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1365,
+        "inf_count": 0,
+        "max": 1.0133289098739624,
+        "mean": 0.987766611226749,
+        "median": 0.9954490661621094,
+        "min": 0.7594255805015564,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.8797195386886597,
+          "25": 0.9850367307662964,
+          "5": 0.9432659149169922,
+          "50": 0.9954490661621094,
+          "75": 0.9999735355377197,
+          "95": 1.0057258367538453,
+          "99": 1.009229893684387
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9954490661621094
+          },
+          {
+            "index": 341,
+            "value": 0.9791178703308105
+          },
+          {
+            "index": 682,
+            "value": 0.9968851208686829
+          },
+          {
+            "index": 1023,
+            "value": 0.9984455108642578
+          },
+          {
+            "index": 1364,
+            "value": 1.0027393102645874
+          }
+        ],
+        "size": 1365,
+        "std": 0.024139350743705445,
+        "sum": 1348.3014243245125,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9993311762809753,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 341,
+            "median": 0.9839388132095337,
+            "start_index": 339,
+            "stop_index": 344
+          },
+          {
+            "center_index": 682,
+            "median": 0.9965722560882568,
+            "start_index": 680,
+            "stop_index": 685
+          },
+          {
+            "center_index": 1023,
+            "median": 0.9984455108642578,
+            "start_index": 1021,
+            "stop_index": 1026
+          },
+          {
+            "center_index": 1364,
+            "median": 1.0013411045074463,
+            "start_index": 1362,
+            "stop_index": 1365
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.20384596659641,
+        "CRPIX1": 1.0,
+        "CRVAL1": 12057.375,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1365
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m46_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1365
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12335.420898437504,
+        "max": 12335.420898437504,
+        "min": 12057.375,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 12057.375
+          },
+          {
+            "index": 341,
+            "value": 12126.886474609375
+          },
+          {
+            "index": 682,
+            "value": 12196.397949218752
+          },
+          {
+            "index": 1023,
+            "value": 12265.909423828127
+          },
+          {
+            "index": 1364,
+            "value": 12335.420898437504
+          }
+        ],
+        "start": 12057.375,
+        "step": 0.20384596659641,
+        "step_median": 0.2038459665964183,
+        "step_std": 1.2037638857350936e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1332,
+        "inf_count": 0,
+        "max": 1.0139120817184448,
+        "mean": 0.973517561549539,
+        "median": 0.99332195520401,
+        "min": 0.49473774433135986,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.6742737650871277,
+          "25": 0.9728740751743317,
+          "5": 0.8733851253986359,
+          "50": 0.99332195520401,
+          "75": 0.9994349479675293,
+          "95": 1.0044060945510864,
+          "99": 1.0084686815738677
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0012753009796143
+          },
+          {
+            "index": 333,
+            "value": 0.9835005402565002
+          },
+          {
+            "index": 666,
+            "value": 0.9982927441596985
+          },
+          {
+            "index": 999,
+            "value": 0.9960401654243469
+          },
+          {
+            "index": 1331,
+            "value": 0.9557479023933411
+          }
+        ],
+        "size": 1332,
+        "std": 0.05811350179356856,
+        "sum": 1296.725391983986,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9985451102256775,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 333,
+            "median": 0.9932483434677124,
+            "start_index": 331,
+            "stop_index": 336
+          },
+          {
+            "center_index": 666,
+            "median": 0.9982927441596985,
+            "start_index": 664,
+            "stop_index": 669
+          },
+          {
+            "center_index": 999,
+            "median": 0.9946168065071106,
+            "start_index": 997,
+            "stop_index": 1002
+          },
+          {
+            "center_index": 1331,
+            "median": 0.9627960920333862,
+            "start_index": 1329,
+            "stop_index": 1332
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.19943739434636,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11804.674804687,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1332
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m47_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1332
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 12070.125976562005,
+        "max": 12070.125976562005,
+        "min": 11804.674804687,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11804.674804687
+          },
+          {
+            "index": 333,
+            "value": 11871.087457004338
+          },
+          {
+            "index": 666,
+            "value": 11937.500109321676
+          },
+          {
+            "index": 999,
+            "value": 12003.912761639014
+          },
+          {
+            "index": 1331,
+            "value": 12070.125976562005
+          }
+        ],
+        "start": 11804.674804687,
+        "step": 0.19943739434636,
+        "step_median": 0.1994373943471146,
+        "step_std": 8.961699585393993e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1317,
+        "inf_count": 0,
+        "max": 1.0196775197982788,
+        "mean": 0.9593682672797321,
+        "median": 0.9878543615341187,
+        "min": 0.2495858520269394,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.5863633060455322,
+          "25": 0.9596217274665833,
+          "5": 0.8054463863372803,
+          "50": 0.9878543615341187,
+          "75": 0.9971714615821838,
+          "95": 1.0038378953933715,
+          "99": 1.0084836196899414
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0046377182006836
+          },
+          {
+            "index": 329,
+            "value": 0.9596343636512756
+          },
+          {
+            "index": 658,
+            "value": 0.9462335705757141
+          },
+          {
+            "index": 987,
+            "value": 0.9832630753517151
+          },
+          {
+            "index": 1316,
+            "value": 0.9992138743400574
+          }
+        ],
+        "size": 1317,
+        "std": 0.0805051018174718,
+        "sum": 1263.4880080074072,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0038787126541138,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 329,
+            "median": 0.9596343636512756,
+            "start_index": 327,
+            "stop_index": 332
+          },
+          {
+            "center_index": 658,
+            "median": 0.9649951457977295,
+            "start_index": 656,
+            "stop_index": 661
+          },
+          {
+            "center_index": 987,
+            "median": 0.9832630753517151,
+            "start_index": 985,
+            "stop_index": 990
+          },
+          {
+            "center_index": 1316,
+            "median": 0.9914083480834961,
+            "start_index": 1314,
+            "stop_index": 1317
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.19556999786284,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11559.567382812,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1317
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m48_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1317
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11816.937499999498,
+        "max": 11816.937499999498,
+        "min": 11559.567382812,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11559.567382812
+          },
+          {
+            "index": 329,
+            "value": 11623.909912108875
+          },
+          {
+            "index": 658,
+            "value": 11688.252441405748
+          },
+          {
+            "index": 987,
+            "value": 11752.594970702623
+          },
+          {
+            "index": 1316,
+            "value": 11816.937499999498
+          }
+        ],
+        "start": 11559.567382812,
+        "step": 0.19556999786284,
+        "step_median": 0.19556999786254892,
+        "step_std": 6.674160502803061e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1269,
+        "inf_count": 0,
+        "max": 1.0743556022644043,
+        "mean": 0.8183857435833918,
+        "median": 0.9481167793273926,
+        "min": 0.005694129038602114,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.04665384560823441,
+          "25": 0.7604947686195374,
+          "5": 0.17897295057773593,
+          "50": 0.9481167793273926,
+          "75": 0.9916372299194336,
+          "95": 1.0054885864257812,
+          "99": 1.0170092344284056
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0392388105392456
+          },
+          {
+            "index": 317,
+            "value": 0.9880177974700928
+          },
+          {
+            "index": 634,
+            "value": 0.10713793337345123
+          },
+          {
+            "index": 951,
+            "value": 0.9905954003334045
+          },
+          {
+            "index": 1268,
+            "value": 0.968689501285553
+          }
+        ],
+        "size": 1269,
+        "std": 0.26443495551691404,
+        "sum": 1038.5315086073242,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.060171127319336,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 317,
+            "median": 0.9880177974700928,
+            "start_index": 315,
+            "stop_index": 320
+          },
+          {
+            "center_index": 634,
+            "median": 0.29913458228111267,
+            "start_index": 632,
+            "stop_index": 637
+          },
+          {
+            "center_index": 951,
+            "median": 0.9905954003334045,
+            "start_index": 949,
+            "stop_index": 954
+          },
+          {
+            "center_index": 1268,
+            "median": 0.9853458404541016,
+            "start_index": 1266,
+            "stop_index": 1269
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.19163190679219,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11328.309570312,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1269
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m49_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1269
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11571.298828124496,
+        "max": 11571.298828124496,
+        "min": 11328.309570312,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11328.309570312
+          },
+          {
+            "index": 317,
+            "value": 11389.056884765125
+          },
+          {
+            "index": 634,
+            "value": 11449.804199218248
+          },
+          {
+            "index": 951,
+            "value": 11510.551513671373
+          },
+          {
+            "index": 1268,
+            "value": 11571.298828124496
+          }
+        ],
+        "start": 11328.309570312,
+        "step": 0.19163190679219,
+        "step_median": 0.19163190679137188,
+        "step_std": 9.048488832183283e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1245,
+        "inf_count": 0,
+        "max": 3.845062255859375,
+        "mean": 0.7458012676719262,
+        "median": 0.9156439900398254,
+        "min": -38.39313507080078,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -1.038745756149292,
+          "25": 0.6946374177932739,
+          "5": 0.1423472195863724,
+          "50": 0.9156439900398254,
+          "75": 0.9856025576591492,
+          "95": 1.0059812545776368,
+          "99": 1.3135232686996416
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.48518848419189453
+          },
+          {
+            "index": 311,
+            "value": 0.6784419417381287
+          },
+          {
+            "index": 622,
+            "value": 0.8814876675605774
+          },
+          {
+            "index": 933,
+            "value": 0.962229311466217
+          },
+          {
+            "index": 1244,
+            "value": -0.7990520000457764
+          }
+        ],
+        "size": 1245,
+        "std": 1.2008464921257551,
+        "sum": 928.5225782515481,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.5646653771400452,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 311,
+            "median": 0.6784419417381287,
+            "start_index": 309,
+            "stop_index": 314
+          },
+          {
+            "center_index": 622,
+            "median": 0.8814876675605774,
+            "start_index": 620,
+            "stop_index": 625
+          },
+          {
+            "center_index": 933,
+            "median": 0.962229311466217,
+            "start_index": 931,
+            "stop_index": 936
+          },
+          {
+            "center_index": 1244,
+            "median": -0.867023229598999,
+            "start_index": 1242,
+            "stop_index": 1245
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.18782028737942,
+        "CRPIX1": 1.0,
+        "CRVAL1": 11105.83203125,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1245
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m50_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1245
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11339.480468749998,
+        "max": 11339.480468749998,
+        "min": 11105.83203125,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 11105.83203125
+          },
+          {
+            "index": 311,
+            "value": 11164.244140625
+          },
+          {
+            "index": 622,
+            "value": 11222.65625
+          },
+          {
+            "index": 933,
+            "value": 11281.068359374998
+          },
+          {
+            "index": 1244,
+            "value": 11339.480468749998
+          }
+        ],
+        "start": 11105.83203125,
+        "step": 0.18782028737942,
+        "step_median": 0.18782028737950895,
+        "step_std": 3.927960200941427e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1231,
+        "inf_count": 0,
+        "max": 1.015554428100586,
+        "mean": 0.9679089481030704,
+        "median": 0.9892725944519043,
+        "min": 0.5039809346199036,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.7311637759208679,
+          "25": 0.9620690643787384,
+          "5": 0.8578657507896423,
+          "50": 0.9892725944519043,
+          "75": 0.9981858432292938,
+          "95": 1.0034105777740479,
+          "99": 1.00616352558136
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.001808762550354
+          },
+          {
+            "index": 307,
+            "value": 0.9557226896286011
+          },
+          {
+            "index": 615,
+            "value": 1.0040339231491089
+          },
+          {
+            "index": 923,
+            "value": 0.9926385283470154
+          },
+          {
+            "index": 1230,
+            "value": 1.0019060373306274
+          }
+        ],
+        "size": 1231,
+        "std": 0.056538341118923426,
+        "sum": 1191.4959151148796,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.000440239906311,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 307,
+            "median": 0.9557226896286011,
+            "start_index": 305,
+            "stop_index": 310
+          },
+          {
+            "center_index": 615,
+            "median": 1.002592921257019,
+            "start_index": 613,
+            "stop_index": 618
+          },
+          {
+            "center_index": 923,
+            "median": 0.9842290878295898,
+            "start_index": 921,
+            "stop_index": 926
+          },
+          {
+            "center_index": 1230,
+            "median": 0.9979926347732544,
+            "start_index": 1228,
+            "stop_index": 1231
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.18415507494919,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10890.102539063,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1231
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m51_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1231
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 11116.613281250504,
+        "max": 11116.613281250504,
+        "min": 10890.102539063,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10890.102539063
+          },
+          {
+            "index": 307,
+            "value": 10946.6381470724
+          },
+          {
+            "index": 615,
+            "value": 11003.357910156752
+          },
+          {
+            "index": 923,
+            "value": 11060.077673241103
+          },
+          {
+            "index": 1230,
+            "value": 11116.613281250504
+          }
+        ],
+        "start": 10890.102539063,
+        "step": 0.18415507494919,
+        "step_median": 0.1841550749486487,
+        "step_std": 8.316153014363072e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1206,
+        "inf_count": 0,
+        "max": 1.0100181102752686,
+        "mean": 0.9900577645100171,
+        "median": 0.9969737827777863,
+        "min": 0.8323075771331787,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.9179726660251617,
+          "25": 0.9876411408185959,
+          "5": 0.9555287510156631,
+          "50": 0.9969737827777863,
+          "75": 1.0001820623874664,
+          "95": 1.0039385259151459,
+          "99": 1.0061812937259673
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0004112720489502
+          },
+          {
+            "index": 301,
+            "value": 0.9990099668502808
+          },
+          {
+            "index": 603,
+            "value": 0.9998164772987366
+          },
+          {
+            "index": 904,
+            "value": 0.9484230279922485
+          },
+          {
+            "index": 1205,
+            "value": 1.00418221950531
+          }
+        ],
+        "size": 1206,
+        "std": 0.018120304947268327,
+        "sum": 1194.0096639990807,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9993415474891663,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 301,
+            "median": 1.0003125667572021,
+            "start_index": 299,
+            "stop_index": 304
+          },
+          {
+            "center_index": 603,
+            "median": 1.0005313158035278,
+            "start_index": 601,
+            "stop_index": 606
+          },
+          {
+            "center_index": 904,
+            "median": 0.954587996006012,
+            "start_index": 902,
+            "stop_index": 907
+          },
+          {
+            "center_index": 1205,
+            "median": 1.0015949010849,
+            "start_index": 1203,
+            "stop_index": 1206
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.18048495850622,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10683.017578125,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1206
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m52_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1206
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10900.501953124995,
+        "max": 10900.501953124995,
+        "min": 10683.017578125,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10683.017578125
+          },
+          {
+            "index": 301,
+            "value": 10737.343550635373
+          },
+          {
+            "index": 603,
+            "value": 10791.850008104251
+          },
+          {
+            "index": 904,
+            "value": 10846.175980614624
+          },
+          {
+            "index": 1205,
+            "value": 10900.501953124995
+          }
+        ],
+        "start": 10683.017578125,
+        "step": 0.18048495850622,
+        "step_median": 0.18048495850598556,
+        "step_std": 6.089808286633043e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1182,
+        "inf_count": 0,
+        "max": 1.0142202377319336,
+        "mean": 0.9959922232704518,
+        "median": 0.9988044798374176,
+        "min": 0.8212175369262695,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.9308307164907456,
+          "25": 0.9955938756465912,
+          "5": 0.9831326067447662,
+          "50": 0.9988044798374176,
+          "75": 1.001516431570053,
+          "95": 1.0051758229732513,
+          "99": 1.0100826382637025
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9939776062965393
+          },
+          {
+            "index": 295,
+            "value": 1.008691430091858
+          },
+          {
+            "index": 591,
+            "value": 0.9944559931755066
+          },
+          {
+            "index": 886,
+            "value": 1.0040255784988403
+          },
+          {
+            "index": 1181,
+            "value": 0.8212175369262695
+          }
+        ],
+        "size": 1182,
+        "std": 0.014731186543182673,
+        "sum": 1177.262807905674,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9911561608314514,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 295,
+            "median": 1.0074083805084229,
+            "start_index": 293,
+            "stop_index": 298
+          },
+          {
+            "center_index": 591,
+            "median": 0.9944559931755066,
+            "start_index": 589,
+            "stop_index": 594
+          },
+          {
+            "center_index": 886,
+            "median": 1.0021001100540161,
+            "start_index": 884,
+            "stop_index": 889
+          },
+          {
+            "center_index": 1181,
+            "median": 0.8404713869094849,
+            "start_index": 1179,
+            "stop_index": 1182
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.1770430911304,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10483.91796875,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1182
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m53_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1182
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10693.005859375002,
+        "max": 10693.005859375002,
+        "min": 10483.91796875,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10483.91796875
+          },
+          {
+            "index": 295,
+            "value": 10536.145680633468
+          },
+          {
+            "index": 591,
+            "value": 10588.550435608066
+          },
+          {
+            "index": 886,
+            "value": 10640.778147491534
+          },
+          {
+            "index": 1181,
+            "value": 10693.005859375002
+          }
+        ],
+        "start": 10483.91796875,
+        "step": 0.1770430911304,
+        "step_median": 0.1770430911310541,
+        "step_std": 8.730429994440193e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1167,
+        "inf_count": 0,
+        "max": 1.0119291543960571,
+        "mean": 0.9982856467123612,
+        "median": 0.9989907145500183,
+        "min": 0.9697721600532532,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.9763450694084167,
+          "25": 0.9963035583496094,
+          "5": 0.9902545571327209,
+          "50": 0.9989907145500183,
+          "75": 1.0012882351875305,
+          "95": 1.004668080806732,
+          "99": 1.0072865509986877
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9971266984939575
+          },
+          {
+            "index": 291,
+            "value": 1.0035879611968994
+          },
+          {
+            "index": 583,
+            "value": 0.9973527193069458
+          },
+          {
+            "index": 875,
+            "value": 1.004420280456543
+          },
+          {
+            "index": 1166,
+            "value": 0.9962143898010254
+          }
+        ],
+        "size": 1167,
+        "std": 0.005210198182341902,
+        "sum": 1164.9993497133255,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0007960796356201,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 291,
+            "median": 1.0035879611968994,
+            "start_index": 289,
+            "stop_index": 294
+          },
+          {
+            "center_index": 583,
+            "median": 0.9973527193069458,
+            "start_index": 581,
+            "stop_index": 586
+          },
+          {
+            "center_index": 875,
+            "median": 0.9996359944343567,
+            "start_index": 873,
+            "stop_index": 878
+          },
+          {
+            "center_index": 1166,
+            "median": 0.9966669678688049,
+            "start_index": 1164,
+            "stop_index": 1167
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.17383063759648,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10290.870117188,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1167
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m54_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1167
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10493.556640625497,
+        "max": 10493.556640625497,
+        "min": 10290.870117188,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10290.870117188
+          },
+          {
+            "index": 291,
+            "value": 10341.454832728576
+          },
+          {
+            "index": 583,
+            "value": 10392.213378906748
+          },
+          {
+            "index": 875,
+            "value": 10442.97192508492
+          },
+          {
+            "index": 1166,
+            "value": 10493.556640625497
+          }
+        ],
+        "start": 10290.870117188,
+        "step": 0.17383063759648,
+        "step_median": 0.17383063759734796,
+        "step_std": 9.085188280640363e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1128,
+        "inf_count": 0,
+        "max": 1.0129162073135376,
+        "mean": 0.9978454616581295,
+        "median": 0.9985979199409485,
+        "min": 0.9720970988273621,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.980386169552803,
+          "25": 0.9956809431314468,
+          "5": 0.9889782279729843,
+          "50": 0.9985979199409485,
+          "75": 1.0009866952896118,
+          "95": 1.0043955266475677,
+          "99": 1.0073958349227905
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9832320213317871
+          },
+          {
+            "index": 282,
+            "value": 0.9888801574707031
+          },
+          {
+            "index": 564,
+            "value": 0.9991770386695862
+          },
+          {
+            "index": 846,
+            "value": 0.9931067228317261
+          },
+          {
+            "index": 1127,
+            "value": 0.9994518756866455
+          }
+        ],
+        "size": 1128,
+        "std": 0.0050288150229109594,
+        "sum": 1125.56968075037,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9886710047721863,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 282,
+            "median": 0.9924750328063965,
+            "start_index": 280,
+            "stop_index": 285
+          },
+          {
+            "center_index": 564,
+            "median": 1.0007648468017578,
+            "start_index": 562,
+            "stop_index": 567
+          },
+          {
+            "center_index": 846,
+            "median": 0.994510293006897,
+            "start_index": 844,
+            "stop_index": 849
+          },
+          {
+            "center_index": 1127,
+            "median": 0.99916011095047,
+            "start_index": 1125,
+            "stop_index": 1128
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.17053190161934,
+        "CRPIX1": 1.0,
+        "CRVAL1": 10107.919921875,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1128
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m55_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1128
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10300.109374999996,
+        "max": 10300.109374999996,
+        "min": 10107.919921875,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 10107.919921875
+          },
+          {
+            "index": 282,
+            "value": 10156.009918131655
+          },
+          {
+            "index": 564,
+            "value": 10204.099914388307
+          },
+          {
+            "index": 846,
+            "value": 10252.189910644962
+          },
+          {
+            "index": 1127,
+            "value": 10300.109374999996
+          }
+        ],
+        "start": 10107.919921875,
+        "step": 0.17053190161934,
+        "step_median": 0.17053190162005194,
+        "step_std": 8.877437137828389e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1126,
+        "inf_count": 0,
+        "max": 1.0347204208374023,
+        "mean": 0.9930212294970694,
+        "median": 0.9980452060699463,
+        "min": 0.8374980092048645,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.8838248252868652,
+          "25": 0.992444634437561,
+          "5": 0.9673216193914413,
+          "50": 0.9980452060699463,
+          "75": 1.0010234713554382,
+          "95": 1.0067024230957031,
+          "99": 1.0284690260887146
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9926982522010803
+          },
+          {
+            "index": 281,
+            "value": 1.0007067918777466
+          },
+          {
+            "index": 563,
+            "value": 0.9960941672325134
+          },
+          {
+            "index": 844,
+            "value": 0.9722777009010315
+          },
+          {
+            "index": 1125,
+            "value": 1.011788010597229
+          }
+        ],
+        "size": 1126,
+        "std": 0.020337007985907957,
+        "sum": 1118.1419044137,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9867801666259766,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 281,
+            "median": 1.00257408618927,
+            "start_index": 279,
+            "stop_index": 284
+          },
+          {
+            "center_index": 563,
+            "median": 0.9991827607154846,
+            "start_index": 561,
+            "stop_index": 566
+          },
+          {
+            "center_index": 844,
+            "median": 0.9676944613456726,
+            "start_index": 842,
+            "stop_index": 847
+          },
+          {
+            "center_index": 1125,
+            "median": 1.0054287910461426,
+            "start_index": 1123,
+            "stop_index": 1126
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.16738454861111,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9928.51269531251,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1126
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m56_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1126
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 10116.820312500007,
+        "max": 10116.820312500007,
+        "min": 9928.51269531251,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9928.51269531251
+          },
+          {
+            "index": 281,
+            "value": 9975.54775347223
+          },
+          {
+            "index": 563,
+            "value": 10022.750196180565
+          },
+          {
+            "index": 844,
+            "value": 10069.785254340286
+          },
+          {
+            "index": 1125,
+            "value": 10116.820312500007
+          }
+        ],
+        "start": 9928.51269531251,
+        "step": 0.16738454861111,
+        "step_median": 0.16738454861115315,
+        "step_std": 2.7839453063596145e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1101,
+        "inf_count": 0,
+        "max": 1.1063352823257446,
+        "mean": 0.9879836636061673,
+        "median": 0.9961000680923462,
+        "min": 0.6666916608810425,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.8082234859466553,
+          "25": 0.9897679090499878,
+          "5": 0.9376755356788635,
+          "50": 0.9961000680923462,
+          "75": 0.9996711015701294,
+          "95": 1.0037490129470825,
+          "99": 1.044335961341858
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.9251348376274109
+          },
+          {
+            "index": 275,
+            "value": 0.9951049089431763
+          },
+          {
+            "index": 550,
+            "value": 0.9678438901901245
+          },
+          {
+            "index": 825,
+            "value": 0.9853495359420776
+          },
+          {
+            "index": 1100,
+            "value": 1.0024551153182983
+          }
+        ],
+        "size": 1101,
+        "std": 0.03467885923914553,
+        "sum": 1087.7700136303902,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9213686585426331,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 275,
+            "median": 0.9951049089431763,
+            "start_index": 273,
+            "stop_index": 278
+          },
+          {
+            "center_index": 550,
+            "median": 0.9833629727363586,
+            "start_index": 548,
+            "stop_index": 553
+          },
+          {
+            "center_index": 825,
+            "median": 0.9853495359420776,
+            "start_index": 823,
+            "stop_index": 828
+          },
+          {
+            "center_index": 1100,
+            "median": 0.9977619051933289,
+            "start_index": 1098,
+            "stop_index": 1101
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.1644140625,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9756.29003906251,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1101
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m57_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1101
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9937.14550781251,
+        "max": 9937.14550781251,
+        "min": 9756.29003906251,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9756.29003906251
+          },
+          {
+            "index": 275,
+            "value": 9801.50390625001
+          },
+          {
+            "index": 550,
+            "value": 9846.71777343751
+          },
+          {
+            "index": 825,
+            "value": 9891.93164062501
+          },
+          {
+            "index": 1100,
+            "value": 9937.14550781251
+          }
+        ],
+        "start": 9756.29003906251,
+        "step": 0.1644140625,
+        "step_median": 0.16441406249941792,
+        "step_std": 8.485151768493295e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1088,
+        "inf_count": 0,
+        "max": 1.1201198101043701,
+        "mean": 0.9152420988539234,
+        "median": 0.9875260889530182,
+        "min": 0.03256775438785553,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.04495355147868395,
+          "25": 0.9343658238649368,
+          "5": 0.5466056942939759,
+          "50": 0.9875260889530182,
+          "75": 0.9992440640926361,
+          "95": 1.0070078849792479,
+          "99": 1.024871928691864
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 0.03365560993552208
+          },
+          {
+            "index": 272,
+            "value": 0.9924880266189575
+          },
+          {
+            "index": 544,
+            "value": 0.9968492388725281
+          },
+          {
+            "index": 816,
+            "value": 1.0057131052017212
+          },
+          {
+            "index": 1087,
+            "value": 0.9462738037109375
+          }
+        ],
+        "size": 1088,
+        "std": 0.19048442776240285,
+        "sum": 995.7834035530686,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.034310173243284225,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 272,
+            "median": 0.9881313443183899,
+            "start_index": 270,
+            "stop_index": 275
+          },
+          {
+            "center_index": 544,
+            "median": 0.9989610910415649,
+            "start_index": 542,
+            "stop_index": 547
+          },
+          {
+            "center_index": 816,
+            "median": 1.0024633407592773,
+            "start_index": 814,
+            "stop_index": 819
+          },
+          {
+            "center_index": 1087,
+            "median": 0.9439103007316589,
+            "start_index": 1085,
+            "stop_index": 1088
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.16145713546458,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9589.11718750001,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1088
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m58_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1088
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9764.621093750007,
+        "max": 9764.621093750007,
+        "min": 9589.11718750001,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9589.11718750001
+          },
+          {
+            "index": 272,
+            "value": 9633.033528346376
+          },
+          {
+            "index": 544,
+            "value": 9676.94986919274
+          },
+          {
+            "index": 816,
+            "value": 9720.866210039107
+          },
+          {
+            "index": 1087,
+            "value": 9764.621093750007
+          }
+        ],
+        "start": 9589.11718750001,
+        "step": 0.16145713546458,
+        "step_median": 0.1614571354639338,
+        "step_std": 8.704689541852579e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1074,
+        "inf_count": 0,
+        "max": 12.294438362121582,
+        "mean": 0.7689792592966412,
+        "median": 0.9463387727737427,
+        "min": -64.7624282836914,
+        "nan_count": 0,
+        "percentiles": {
+          "1": -0.6778178948163986,
+          "25": 0.7869940102100372,
+          "5": 0.2179357275366783,
+          "50": 0.9463387727737427,
+          "75": 0.9980251044034958,
+          "95": 1.017591482400894,
+          "99": 1.526234729290007
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.004763126373291
+          },
+          {
+            "index": 268,
+            "value": 0.935326337814331
+          },
+          {
+            "index": 537,
+            "value": 1.0171946287155151
+          },
+          {
+            "index": 805,
+            "value": 0.9894920587539673
+          },
+          {
+            "index": 1073,
+            "value": -0.1671058088541031
+          }
+        ],
+        "size": 1074,
+        "std": 2.0976636621972,
+        "sum": 825.8837244845927,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 0.9991342425346375,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 268,
+            "median": 0.9769182801246643,
+            "start_index": 266,
+            "stop_index": 271
+          },
+          {
+            "center_index": 537,
+            "median": 1.0111405849456787,
+            "start_index": 535,
+            "stop_index": 540
+          },
+          {
+            "center_index": 805,
+            "median": 0.9895317554473877,
+            "start_index": 803,
+            "stop_index": 808
+          },
+          {
+            "center_index": 1073,
+            "median": -0.1815403252840042,
+            "start_index": 1071,
+            "stop_index": 1074
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.15857627562908,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9427.04492187501,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1074
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m59_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1074
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9597.197265625013,
+        "max": 9597.197265625013,
+        "min": 9427.04492187501,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9427.04492187501
+          },
+          {
+            "index": 268,
+            "value": 9469.543363743602
+          },
+          {
+            "index": 537,
+            "value": 9512.200381887826
+          },
+          {
+            "index": 805,
+            "value": 9554.698823756418
+          },
+          {
+            "index": 1073,
+            "value": 9597.197265625013
+          }
+        ],
+        "start": 9427.04492187501,
+        "step": 0.15857627562908,
+        "step_median": 0.1585762756294571,
+        "step_std": 7.368374898866198e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1034,
+        "inf_count": 0,
+        "max": 1.8247613906860352,
+        "mean": 0.8789133501655244,
+        "median": 0.9461210072040558,
+        "min": 0.08232757449150085,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.1469889523088932,
+          "25": 0.8077687919139862,
+          "5": 0.3286480143666268,
+          "50": 0.9461210072040558,
+          "75": 0.9970250278711319,
+          "95": 1.2038306474685665,
+          "99": 1.6069766342639915
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0030794143676758
+          },
+          {
+            "index": 258,
+            "value": 0.9354674220085144
+          },
+          {
+            "index": 517,
+            "value": 0.8979607820510864
+          },
+          {
+            "index": 775,
+            "value": 0.882724940776825
+          },
+          {
+            "index": 1033,
+            "value": 1.0040123462677002
+          }
+        ],
+        "size": 1034,
+        "std": 0.25339470593172697,
+        "sum": 908.7964040711522,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0019612312316895,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 258,
+            "median": 0.9354674220085144,
+            "start_index": 256,
+            "stop_index": 261
+          },
+          {
+            "center_index": 517,
+            "median": 0.8979607820510864,
+            "start_index": 515,
+            "stop_index": 520
+          },
+          {
+            "center_index": 775,
+            "median": 0.882724940776825,
+            "start_index": 773,
+            "stop_index": 778
+          },
+          {
+            "center_index": 1033,
+            "median": 0.9968953728675842,
+            "start_index": 1031,
+            "stop_index": 1034
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.15587468992014,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9273.76269531251,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1034
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m60_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1034
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9434.781250000015,
+        "max": 9434.781250000015,
+        "min": 9273.76269531251,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9273.76269531251
+          },
+          {
+            "index": 258,
+            "value": 9313.978365311905
+          },
+          {
+            "index": 517,
+            "value": 9354.349910001221
+          },
+          {
+            "index": 775,
+            "value": 9394.565580000617
+          },
+          {
+            "index": 1033,
+            "value": 9434.781250000015
+          }
+        ],
+        "start": 9273.76269531251,
+        "step": 0.15587468992014,
+        "step_median": 0.1558746899208927,
+        "step_std": 8.957361405449461e-13
+      }
+    },
+    {
+      "dtype": ">f4",
+      "flux": {
+        "finite_count": 1039,
+        "inf_count": 0,
+        "max": 1.0564405918121338,
+        "mean": 0.9472191282140164,
+        "median": 0.9871150255203247,
+        "min": 0.5794547200202942,
+        "nan_count": 0,
+        "percentiles": {
+          "1": 0.6412710607051849,
+          "25": 0.929225355386734,
+          "5": 0.7268238663673401,
+          "50": 0.9871150255203247,
+          "75": 0.9993212223052979,
+          "95": 1.018038558959961,
+          "99": 1.0504632210731506
+        },
+        "samples": [
+          {
+            "index": 0,
+            "value": 1.0530256032943726
+          },
+          {
+            "index": 259,
+            "value": 0.9928900599479675
+          },
+          {
+            "index": 519,
+            "value": 0.9834245443344116
+          },
+          {
+            "index": 779,
+            "value": 0.9107458591461182
+          },
+          {
+            "index": 1038,
+            "value": 0.6795950531959534
+          }
+        ],
+        "size": 1039,
+        "std": 0.08935536290154922,
+        "sum": 984.1606742143631,
+        "window_medians": [
+          {
+            "center_index": 0,
+            "median": 1.0530256032943726,
+            "start_index": 0,
+            "stop_index": 3
+          },
+          {
+            "center_index": 259,
+            "median": 0.9928900599479675,
+            "start_index": 257,
+            "stop_index": 262
+          },
+          {
+            "center_index": 519,
+            "median": 0.984874427318573,
+            "start_index": 517,
+            "stop_index": 522
+          },
+          {
+            "center_index": 779,
+            "median": 0.9340551495552063,
+            "start_index": 777,
+            "stop_index": 782
+          },
+          {
+            "center_index": 1038,
+            "median": 0.8396458625793457,
+            "start_index": 1036,
+            "stop_index": 1039
+          }
+        ]
+      },
+      "header": {
+        "AIRORVAC": "vac",
+        "CDELT1": 0.15320459266618,
+        "CRPIX1": 1.0,
+        "CRVAL1": 9122.20996093751,
+        "CTYPE1": "LINEAR",
+        "NAXIS": 1,
+        "NAXIS1": 1039
+      },
+      "path": "4_Ari_sum/VAC_norm/fsr1.05/4_Ari_sum_m61_fsr1.05_VAC_norm.fits",
+      "shape": [
+        1039
+      ],
+      "wavelength": {
+        "available": true,
+        "end": 9281.236328125004,
+        "max": 9281.236328125004,
+        "min": 9122.20996093751,
+        "monotonic_increasing": true,
+        "samples": [
+          {
+            "index": 0,
+            "value": 9122.20996093751
+          },
+          {
+            "index": 259,
+            "value": 9161.88995043805
+          },
+          {
+            "index": 519,
+            "value": 9201.723144531257
+          },
+          {
+            "index": 779,
+            "value": 9241.556338624463
+          },
+          {
+            "index": 1038,
+            "value": 9281.236328125004
+          }
+        ],
+        "start": 9122.20996093751,
+        "step": 0.15320459266618,
+        "step_median": 0.15320459266695252,
+        "step_std": 8.991647562580567e-13
+      }
+    }
+  ],
+  "root_name": "4_Ari_WIDE_test",
+  "schema_version": 1
+}

--- a/tests/test_1d_spectrum_summary.py
+++ b/tests/test_1d_spectrum_summary.py
@@ -1,0 +1,70 @@
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from tools.summarize_1d_spectra import summarize_fits, summarize_tree
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REFERENCE_SUMMARY = REPO_ROOT / "tests/reference/wide_4_ari_1d_summary.json"
+
+
+def write_spectrum(path, data, crval=1000.0, cdelt=0.5, air_or_vac="air"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    hdu = fits.PrimaryHDU(np.asarray(data, dtype=np.float32))
+    hdu.header["CRVAL1"] = crval
+    hdu.header["CRPIX1"] = 1.0
+    hdu.header["CDELT1"] = cdelt
+    hdu.header["CTYPE1"] = "LINEAR"
+    hdu.header["AIRORVAC"] = air_or_vac
+    hdu.writeto(path)
+
+
+def test_summarize_fits_records_wavelength_and_flux_statistics(tmp_path):
+    spectrum = tmp_path / "star_sum/AIR_norm/fsr1.05/star_m52_fsr1.05_AIR_norm.fits"
+    write_spectrum(spectrum, [1.0, 2.0, np.nan, 4.0, 5.0])
+
+    summary = summarize_fits(spectrum, tmp_path)
+
+    assert summary["path"] == "star_sum/AIR_norm/fsr1.05/star_m52_fsr1.05_AIR_norm.fits"
+    assert summary["shape"] == [5]
+    assert summary["header"]["AIRORVAC"] == "air"
+    assert summary["wavelength"]["start"] == 1000.0
+    assert summary["wavelength"]["end"] == 1002.0
+    assert summary["wavelength"]["step"] == 0.5
+    assert summary["wavelength"]["monotonic_increasing"] is True
+    assert summary["flux"]["finite_count"] == 4
+    assert summary["flux"]["nan_count"] == 1
+    assert summary["flux"]["median"] == 3.0
+    assert summary["flux"]["samples"][0] == {"index": 0, "value": 1.0}
+
+
+def assert_close(actual, expected, path="summary"):
+    if isinstance(expected, dict):
+        assert set(actual) == set(expected), path
+        for key in expected:
+            assert_close(actual[key], expected[key], f"{path}.{key}")
+    elif isinstance(expected, list):
+        assert len(actual) == len(expected), path
+        for index, expected_item in enumerate(expected):
+            assert_close(actual[index], expected_item, f"{path}[{index}]")
+    elif isinstance(expected, float):
+        assert actual == pytest.approx(expected, rel=1e-6, abs=1e-6), path
+    else:
+        assert actual == expected, path
+
+
+@pytest.mark.regression
+def test_wide_4_ari_1d_summary_matches_reference():
+    output_root = os.environ.get("WARP_1D_OUTPUT_ROOT")
+    if not output_root:
+        pytest.skip("Set WARP_1D_OUTPUT_ROOT to compare a WARP output tree")
+
+    actual = summarize_tree(Path(output_root))
+    expected = json.loads(REFERENCE_SUMMARY.read_text())
+
+    assert_close(actual, expected)

--- a/tools/summarize_1d_spectra.py
+++ b/tools/summarize_1d_spectra.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Summarize WARP 1D spectrum FITS outputs for regression tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+
+
+HEADER_KEYS = (
+    "NAXIS",
+    "NAXIS1",
+    "CRVAL1",
+    "CRPIX1",
+    "CDELT1",
+    "CTYPE1",
+    "CUNIT1",
+    "BUNIT",
+    "AIRORVAC",
+)
+
+
+def json_safe_float(value):
+    if value is None:
+        return None
+    value = float(value)
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def summarize_array(values):
+    flat = np.asarray(values, dtype=np.float64).reshape(-1)
+    finite = flat[np.isfinite(flat)]
+    summary = {
+        "size": int(flat.size),
+        "finite_count": int(finite.size),
+        "nan_count": int(np.isnan(flat).sum()),
+        "inf_count": int(np.isinf(flat).sum()),
+    }
+    if finite.size == 0:
+        summary.update(
+            {
+                "min": None,
+                "max": None,
+                "mean": None,
+                "median": None,
+                "std": None,
+                "sum": None,
+                "percentiles": {},
+                "samples": [],
+                "window_medians": [],
+            }
+        )
+        return summary
+
+    summary.update(
+        {
+            "min": json_safe_float(np.min(finite)),
+            "max": json_safe_float(np.max(finite)),
+            "mean": json_safe_float(np.mean(finite)),
+            "median": json_safe_float(np.median(finite)),
+            "std": json_safe_float(np.std(finite)),
+            "sum": json_safe_float(np.sum(finite)),
+            "percentiles": {
+                str(percentile): json_safe_float(np.percentile(finite, percentile))
+                for percentile in (1, 5, 25, 50, 75, 95, 99)
+            },
+            "samples": sample_points(flat),
+            "window_medians": window_medians(flat),
+        }
+    )
+    return summary
+
+
+def sample_indices(size):
+    if size <= 0:
+        return []
+    indices = {0, size // 4, size // 2, (3 * size) // 4, size - 1}
+    return sorted(indices)
+
+
+def sample_points(values):
+    samples = []
+    for index in sample_indices(values.size):
+        samples.append({"index": int(index), "value": json_safe_float(values[index])})
+    return samples
+
+
+def window_medians(values, half_width=2):
+    windows = []
+    for index in sample_indices(values.size):
+        start = max(0, index - half_width)
+        stop = min(values.size, index + half_width + 1)
+        window = values[start:stop]
+        finite = window[np.isfinite(window)]
+        median = None if finite.size == 0 else json_safe_float(np.median(finite))
+        windows.append(
+            {
+                "center_index": int(index),
+                "start_index": int(start),
+                "stop_index": int(stop),
+                "median": median,
+            }
+        )
+    return windows
+
+
+def wavelength_summary(header, size):
+    crval = header.get("CRVAL1")
+    crpix = header.get("CRPIX1")
+    cdelt = header.get("CDELT1")
+    if size <= 0 or crval is None or crpix is None or cdelt is None:
+        return {
+            "available": False,
+            "start": None,
+            "end": None,
+            "step": None,
+            "monotonic_increasing": None,
+        }
+
+    indices = np.arange(size, dtype=np.float64) + 1.0
+    wave = float(crval) + (indices - float(crpix)) * float(cdelt)
+    diffs = np.diff(wave)
+    return {
+        "available": True,
+        "start": json_safe_float(wave[0]),
+        "end": json_safe_float(wave[-1]),
+        "min": json_safe_float(np.min(wave)),
+        "max": json_safe_float(np.max(wave)),
+        "step": json_safe_float(float(cdelt)),
+        "step_median": json_safe_float(np.median(diffs)) if diffs.size else None,
+        "step_std": json_safe_float(np.std(diffs)) if diffs.size else None,
+        "monotonic_increasing": bool(np.all(diffs > 0)) if diffs.size else True,
+        "samples": sample_points(wave),
+    }
+
+
+def summarize_fits(path, root):
+    with fits.open(path, memmap=False) as hdul:
+        hdu = hdul[0]
+        data = np.asarray(hdu.data)
+        if data.ndim != 1:
+            raise ValueError(f"{path} is not a 1D spectrum: shape={data.shape}")
+        header = {key: hdu.header[key] for key in HEADER_KEYS if key in hdu.header}
+        return {
+            "path": path.relative_to(root).as_posix(),
+            "shape": list(data.shape),
+            "dtype": str(data.dtype),
+            "header": header,
+            "wavelength": wavelength_summary(hdu.header, data.size),
+            "flux": summarize_array(data),
+        }
+
+
+def find_1d_spectra(root):
+    patterns = (
+        "*_sum/AIR_norm/fsr*/*.fits",
+        "*_sum/VAC_norm/fsr*/*.fits",
+        "*_sum/AIR_flux/fsr*/*.fits",
+        "*_sum/VAC_flux/fsr*/*.fits",
+    )
+    paths = []
+    for pattern in patterns:
+        paths.extend(root.glob(pattern))
+    return sorted(set(path for path in paths if path.is_file()))
+
+
+def summarize_tree(root):
+    root = Path(root).resolve()
+    files = find_1d_spectra(root)
+    if not files:
+        raise FileNotFoundError(f"No 1D spectrum FITS files found below {root}")
+    return {
+        "schema_version": 1,
+        "root_name": root.name,
+        "file_count": len(files),
+        "files": [summarize_fits(path, root) for path in files],
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path, help="WARP output tree containing *_sum directories")
+    parser.add_argument("--output", "-o", type=Path, help="Write summary JSON to this path")
+    args = parser.parse_args(argv)
+
+    summary = summarize_tree(args.root)
+    text = json.dumps(summary, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(text + "\n")
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a WIDE smoke test for Warp_calib.py.
- Clean up smoke test shell scripts so they can run from any working directory.
- Add lightweight 1D spectrum regression summaries for Warp_sci.py outputs.
- Keep generated FITS products out of git; compare numerical JSON summaries instead.

## Testing
- /Users/hamano/miniconda3/envs/warp-py313-pyraf/bin/python -m pytest -q
- WARP_1D_OUTPUT_ROOT=TEST/4_Ari_WIDE_test /Users/hamano/miniconda3/envs/warp-py313-pyraf/bin/python -m pytest -q -m regression
- PYTHON=/Users/hamano/miniconda3/envs/warp-py313-pyraf/bin/python iraf=/Users/hamano/iraf/iraf-2.17.1/ ./testWarpSci.sh
- ./testWarpCalib.sh

## Japanese summary

このPRは、実行テストと数値回帰テストを一段増やすための変更です。

- `Warp_calib.py` 用のWIDE smoke testを追加しました。
- `testWarpSci.sh` / `testWarpSciFull.sh` のパス処理を整理し、どのカレントディレクトリからでも実行しやすくしました。
- テスト出力は一時ディレクトリに作り、必要な場合だけ `KEEP_WARP_TEST_OUTPUT=1` で残せるようにしました。
- 最終的な1次元スペクトルについて、FITS本体ではなく軽量なJSON summaryで数値回帰比較できるようにしました。
- 1D summaryでは、波長範囲、波長刻み、flux統計量、percentile、固定サンプル点などを記録します。

科学出力そのものを変更する意図はありません。生成されたFITSをgitに入れず、比較用の小さなJSONだけを参照値として管理します。
